### PR TITLE
lds: support resolver extensibility.

### DIFF
--- a/api/address.proto
+++ b/api/address.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
 
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 // [V2-API-DIFF] Addresses now have .proto structure.
@@ -23,16 +22,16 @@ message Address {
     string path = 1;
   }
   // Support pluggable resolvers.
-  message ResolverAddress {
+  message Resolver {
     // Name of the resolver. This must have been registered with Envoy.
     string name = 1;
-    // Opaque data passed to the resolver. The resolver will translate this
-    // to a SocketAddress.
-    google.protobuf.Struct data = 2;
+    // TODO(htuch): Do we need further extensibility or should we collapse
+    // Resolver to a string?
   }
+  // If not specified, the default DNS resolver is used.
+  Resolver resolver = 1;
   oneof address {
-    SocketAddress socket_address = 1;
-    Pipe pipe = 2;
-    ResolverAddress resolver_address = 3;
+    SocketAddress socket_address = 2;
+    Pipe pipe = 3;
   }
 }

--- a/api/address.proto
+++ b/api/address.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 // [V2-API-DIFF] Addresses now have .proto structure.
@@ -8,14 +9,23 @@ message Address {
     // For listeners, bind to 0.0.0.0 or :: to support the use of prefix/suffix
     // matching in FilterChainMatch. For clusters, an address may be either an
     // IP or hostname to be resolved via DNS.
-    google.protobuf.StringValue address = 1;
+    string address = 1;
     google.protobuf.UInt32Value port = 2;
   }
   message Pipe {
-    google.protobuf.StringValue path = 1;
+    string path = 1;
+  }
+  // Support pluggable resolvers.
+  message ResolverAddress {
+    // Name of the resolver. This must have been registered with Envoy.
+    string name = 1;
+    // Opaque data passed to the resolver. The resolver will translate this
+    // to a SocketAddress.
+    google.protobuf.Struct data = 2;
   }
   oneof address {
     SocketAddress socket_address = 1;
     Pipe pipe = 2;
+    ResolverAddress resolver_address = 3;
   }
 }

--- a/api/address.proto
+++ b/api/address.proto
@@ -13,7 +13,7 @@ message Address {
     // matching in FilterChainMatch. For clusters, an address may be either an
     // IP or hostname to be resolved via DNS.
     google.protobuf.StringValue address = 2;
-    oneof port {
+    oneof port_specifier {
       google.protobuf.UInt32Value port = 3;
       string service = 4;
     }

--- a/api/address.proto
+++ b/api/address.proto
@@ -1,8 +1,15 @@
 syntax = "proto3";
 
 // [V2-API-DIFF] Addresses now have .proto structure.
-message Address {
-  message SocketAddress {
+
+message Pipe {
+  string path = 1;
+}
+
+// Unresolved addresses contain either named hosts or ports that require
+// resolution via DNS or an optional custom Resolver.
+message UnresolvedAddress {
+  message NamedAddress {
     enum Protocol {
       TCP = 0;
     }
@@ -12,14 +19,11 @@ message Address {
     // in FilterChainMatch after connection.
     // For clusters, an address may be either an IP or hostname to be resolved via
     // DNS.
-    string address = 2;
+    string host_name = 2;
     oneof port_specifier {
       uint32 port = 3;
-      string service = 4;
+      string service_name = 4;
     }
-  }
-  message Pipe {
-    string path = 1;
   }
   // Support pluggable resolvers.
   message Resolver {
@@ -31,7 +35,32 @@ message Address {
   // If not specified, the default DNS resolver is used.
   Resolver resolver = 1;
   oneof address {
+    NamedAddress named_address = 2;
+    Pipe pipe = 3;
+  }
+}
+
+message UnresolvedAddresses {
+  repeated UnresolvedAddress addresses = 1;
+}
+
+// A ResolvedAddress identifies a concrete socket or UDS path and is not subject
+// to further resolution via DNS or custom resolvers.
+message ResolvedAddress {
+  message SocketAddress {
+    enum Protocol {
+      TCP = 0;
+    }
+    Protocol protocol = 1;
+    string ip_address = 2;
+    uint32 port = 3;
+  }
+  oneof address {
     SocketAddress socket_address = 2;
     Pipe pipe = 3;
   }
+}
+
+message ResolvedAddresses {
+  repeated ResolvedAddress addresses = 1;
 }

--- a/api/address.proto
+++ b/api/address.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "google/protobuf/wrappers.proto";
+
 // [V2-API-DIFF] Addresses now have .proto structure.
 
 message Pipe {
@@ -21,7 +23,7 @@ message UnresolvedAddress {
     // DNS.
     string host_name = 2;
     oneof port_specifier {
-      uint32 port = 3;
+      google.protobuf.UInt32Value port = 3;
       string service_name = 4;
     }
   }
@@ -53,7 +55,7 @@ message ResolvedAddress {
     }
     Protocol protocol = 1;
     string ip_address = 2;
-    uint32 port = 3;
+    google.protobuf.UInt32Value port = 3;
   }
   oneof address {
     SocketAddress socket_address = 2;

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -95,33 +95,36 @@ message Cluster {
   }
   LbPolicy lb_policy = 5;
 
-  // If the service discovery type is static, strict_dns, or logical_dns
-  // the hosts array is required.
-  repeated Address hosts = 6;
+  // If the service discovery type is static, static_hosts is required. If the
+  // service discovery type is strict_dns or logical_dns, dns_hosts is required.
+  oneof hosts_specifier {
+    ResolvedAddresses static_hosts = 6;
+    UnresolvedAddress dns_hosts = 7;
+  }
 
   // Optional active health checking configuration for the cluster. If no
   // configuration is specified no health checking will be done and all cluster
   // members will be considered healthy at all times.
-  repeated HealthCheck health_check = 7;
+  repeated HealthCheck health_check = 8;
 
   // Optional maximum requests for a single upstream connection. This parameter
   // is respected by both the HTTP/1.1 and HTTP/2 connection pool
   // implementations. If not specified, there is no limit. Setting this
   // parameter to 1 will effectively disable keep alive.
-  google.protobuf.UInt32Value max_requests_per_connection = 8;
+  google.protobuf.UInt32Value max_requests_per_connection = 9;
 
   // Optional circuit breaking settings for the cluster.
-  CircuitBreakers circuit_breakers = 9;
+  CircuitBreakers circuit_breakers = 10;
 
   // The TLS configuration for connections to the upstream cluster. If no TLS
   // configuration is specified, TLS will not be used for new connections.
-  UpstreamTlsContext tls_context = 10;
+  UpstreamTlsContext tls_context = 11;
 
   oneof protocol_options {
-    TcpProtocolOptions tcp_protocol_options = 11;
-    Http1ProtocolOptions http_protocol_options  = 12;
-    Http2ProtocolOptions http2_protocol_options  = 13;
-    GrpcProtocolOptions grpc_protocol_options  = 14;
+    TcpProtocolOptions tcp_protocol_options = 12;
+    Http1ProtocolOptions http_protocol_options  = 13;
+    Http2ProtocolOptions http2_protocol_options  = 14;
+    GrpcProtocolOptions grpc_protocol_options  = 15;
   }
 
   // If the dns refresh rate is specified and the cluster type is either
@@ -129,7 +132,7 @@ message Cluster {
   // rate. If this setting is not specified, the value defaults to 5000. For
   // cluster types other than strict_dns and logical_dns this setting is
   // ignored.
-  Duration dns_refresh_rate = 15;
+  Duration dns_refresh_rate = 16;
 
   // If specified, outlier detection will be enabled for this upstream cluster.
   message OutlierDetection {
@@ -175,5 +178,5 @@ message Cluster {
     // be 1900. Defaults to 1900.
     google.protobuf.UInt32Value success_rate_stdev_factor = 9;
   }
-  OutlierDetection outlier_detection = 16;
+  OutlierDetection outlier_detection = 17;
 }

--- a/api/eds.proto
+++ b/api/eds.proto
@@ -50,7 +50,7 @@ message EndpointDiscoveryRequest {
 
 message LbEndpoint {
   // Endpoint host address.
-  Address address = 1;
+  ResolvedAddress address = 1;
 
   // Optional health status when known and supplied by EDS server.
   HealthStatus health_status = 2;

--- a/api/lds.proto
+++ b/api/lds.proto
@@ -86,7 +86,7 @@ message FilterChain {
 
 message Listener {
   // The address that the listener should listen on.
-  Address address = 1;
+  UnresolvedAddress address = 1;
 
   // A list of filter chains to consider for this listener. The FilterChain with
   // the most specific FilterChainMatch criteria is used on a connection. The


### PR DESCRIPTION
This will be useful for Google and other site specific extension of the
resolving of both names and ports. For listeners, ports and bound
addresses can be expressed in a site-specific format. For upstreams,
host names can be resolved using the plugin.