### PR TITLE
lds: empty address implies bind 0.0.0.0/::.

### DIFF
--- a/api/address.proto
+++ b/api/address.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-import "google/protobuf/wrappers.proto";
-
 // [V2-API-DIFF] Addresses now have .proto structure.
 message Address {
   message SocketAddress {
@@ -16,12 +14,12 @@ message Address {
     // DNS.
     string address = 2;
     oneof port_specifier {
-      google.protobuf.UInt32Value port = 3;
+      uint32 port = 3;
       string service = 4;
     }
   }
   message Pipe {
-    google.protobuf.StringValue path = 1;
+    string path = 1;
   }
   oneof address {
     SocketAddress socket_address = 1;

--- a/api/address.proto
+++ b/api/address.proto
@@ -9,9 +9,10 @@ message Address {
       TCP = 0;
     }
     Protocol protocol = 1;
-    // For listeners, an empty address implies a bind to 0.0.0.0 or ::. This
-    // supports the use of prefix/suffix matching in FilterChainMatch. For
-    // clusters, an address may be either an IP or hostname to be resolved via
+    // For listeners, an empty address implies a bind to 0.0.0.0 or ::. It's
+    // still possible to distinguish on address via the prefix/suffix matching
+    // in FilterChainMatch after connection.
+    // For clusters, an address may be either an IP or hostname to be resolved via
     // DNS.
     string address = 2;
     oneof port {

--- a/api/address.proto
+++ b/api/address.proto
@@ -9,10 +9,11 @@ message Address {
       TCP = 0;
     }
     Protocol protocol = 1;
-    // For listeners, bind to 0.0.0.0 or :: to support the use of prefix/suffix
-    // matching in FilterChainMatch. For clusters, an address may be either an
-    // IP or hostname to be resolved via DNS.
-    google.protobuf.StringValue address = 2;
+    // For listeners, an empty address implies a bind to 0.0.0.0 or ::. This
+    // supports the use of prefix/suffix matching in FilterChainMatch. For
+    // clusters, an address may be either an IP or hostname to be resolved via
+    // DNS.
+    string address = 2;
     oneof port {
       google.protobuf.UInt32Value port = 3;
       string service = 4;

--- a/api/lds.proto
+++ b/api/lds.proto
@@ -113,6 +113,9 @@ message Listener {
   // the listener associated with the original destination port. If there is no
   // listener associated with the original destination port, the connection is
   // handled by the listener that receives it. Default is false.
+  // TODO(htuch): Clarify how use_original_dst interacts with listeners that
+  // bind to specific IP addresses, where we want the original destination IP to
+  // be used in the FilterChainMatch but not on bind.
   google.protobuf.BoolValue use_original_dst = 4;
 
   // Soft limit on size of the listener’s new connection read and write buffers.


### PR DESCRIPTION
As discussed offline and in https://github.com/lyft/envoy-api/issues/14.