### PR TITLE
Replace custom Duration with google.protobuf.Duration well known type.

### DIFF
--- a/api/base.proto
+++ b/api/base.proto
@@ -4,6 +4,7 @@ package envoy.api.v2;
 
 import "api/address.proto";
 
+import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -26,10 +27,6 @@ message Node {
   string id = 1;
   google.protobuf.Struct metadata = 2;
   Locality locality = 3;
-}
-
-message Duration {
-  google.protobuf.UInt32Value milliseconds = 1;
 }
 
 message Endpoint {

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -7,6 +7,7 @@ import "api/base.proto";
 import "api/health_check.proto";
 import "api/tls_context.proto";
 
+import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 service ClusterDiscoveryService {
@@ -83,7 +84,7 @@ message Cluster {
   DiscoveryType type = 2;
 
   // The timeout for new network connections to hosts in the cluster.
-  Duration connect_timeout = 3;
+  google.protobuf.Duration connect_timeout = 3;
   // Soft limit on size of the cluster’s connections read and write buffers. If
   // unspecified, an implementation defined default is applied (1MiB).
   google.protobuf.UInt32Value per_connection_buffer_limit_bytes = 4;
@@ -134,7 +135,7 @@ message Cluster {
   // rate. If this setting is not specified, the value defaults to 5000. For
   // cluster types other than strict_dns and logical_dns this setting is
   // ignored.
-  Duration dns_refresh_rate = 16;
+  google.protobuf.Duration dns_refresh_rate = 16;
 
   // If specified, outlier detection will be enabled for this upstream cluster.
   message OutlierDetection {
@@ -144,11 +145,11 @@ message Cluster {
     // The time interval between ejection analysis sweeps. This can result in
     // both new ejections as well as hosts being returned to service. Defaults
     // to 10000ms or 10s.
-    Duration interval = 2;
+    google.protobuf.Duration interval = 2;
     // The base time that a host is ejected for. The real time is equal to the
     // base time multiplied by the number of times the host has been ejected.
     // Defaults to 30000ms or 30s.
-    Duration base_ejection_time = 3;
+    google.protobuf.Duration base_ejection_time = 3;
     // The maximum % of an upstream cluster that can be ejected due to outlier
     // detection. Defaults to 10%.
     google.protobuf.UInt32Value max_ejection_percent = 4;

--- a/api/eds.proto
+++ b/api/eds.proto
@@ -6,6 +6,7 @@ import "api/address.proto";
 import "api/base.proto";
 import "api/health_check.proto";
 
+import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 service EndpointDiscoveryService {
@@ -186,5 +187,5 @@ message ClusterLoadBalance {
 message LoadBalanceResponse {
   repeated ClusterLoadBalance clusters = 1;
   // The default is 10 seconds.
-  Duration load_reporting_interval = 2;
+  google.protobuf.Duration load_reporting_interval = 2;
 }

--- a/api/hds.proto
+++ b/api/hds.proto
@@ -5,6 +5,8 @@ package envoy.api.v2;
 import "api/base.proto";
 import "api/health_check.proto";
 
+import "google/protobuf/duration.proto";
+
 // HDS is Health Discovery Service. It compliments Envoy’s health checking
 // service by designating this Envoy to be a healthchecker for a subset of hosts
 // in the cluster. The status of these health checks will be reported to the
@@ -102,5 +104,5 @@ message ClusterHealthCheck {
 message HealthCheckSpecifier {
   repeated ClusterHealthCheck health_check = 1;
   // The default is 1 second.
-  Duration interval = 2;
+  google.protobuf.Duration interval = 2;
 }

--- a/api/health_check.proto
+++ b/api/health_check.proto
@@ -4,17 +4,18 @@ package envoy.api.v2;
 
 import "api/base.proto";
 
+import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 message HealthCheck {
   // The time to wait for a health check response. If the timeout is reached the
   // health check attempt will be considered a failure.
-  Duration timeout = 1;
+  google.protobuf.Duration timeout = 1;
   // The interval between health checks.
-  Duration interval = 2;
+  google.protobuf.Duration interval = 2;
   // An optional jitter amount in millseconds. If specified, during every
   // internal Envoy will add 0 to interval_jitter to the wait time.
-  Duration interval_jitter = 3;
+  google.protobuf.Duration interval_jitter = 3;
 
   // The number of unhealthy health checks required before a host is marked
   // unhealthy. Note that for http health checking if a host responds with 503


### PR DESCRIPTION
This provides some free conversion routines in the various language
proto bindings, e.g. conversion from Python datetime.timedelta.