### PR TITLE
filter: http_connection_manager proto.

### DIFF
--- a/api/base.proto
+++ b/api/base.proto
@@ -33,11 +33,9 @@ message Endpoint {
 
 // Runtime derived uint32 with a default when not specified.
 message RuntimeUInt32 {
-  oneof value_specifier {
-    // Default value if runtime value is not available.
-    uint32 default_value = 2;
+  // Default value if runtime value is not available.
+  uint32 default_value = 2;
 
-    // Runtime key to get value for comparision. This value is used if defined.
-    string runtime_key = 3;
-  }
+  // Runtime key to get value for comparision. This value is used if defined.
+  string runtime_key = 3;
 }

--- a/api/base.proto
+++ b/api/base.proto
@@ -30,3 +30,14 @@ message Node {
 message Endpoint {
   ResolvedAddress address = 1;
 }
+
+// Runtime derived uint32 with a default when not specified.
+message RuntimeUInt32 {
+  oneof value_specifier {
+    // Default value if runtime value is not available.
+    uint32 default_value = 2;
+
+    // Runtime key to get value for comparision. This value is used if defined.
+    string runtime_key = 3;
+  }
+}

--- a/api/filter/BUILD
+++ b/api/filter/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:api_build_system.bzl", "api_proto_library")
+
+api_proto_library(
+    name = "http_connection_manager",
+    srcs = ["http_connection_manager.proto"],
+    deps = [
+        "//api:cds",
+        "//api:rds",
+    ],
+)

--- a/api/filter/BUILD
+++ b/api/filter/BUILD
@@ -4,6 +4,7 @@ api_proto_library(
     name = "http_connection_manager",
     srcs = ["http_connection_manager.proto"],
     deps = [
+        "//api:base",
         "//api:cds",
         "//api:rds",
     ],

--- a/api/filter/http_connection_manager.proto
+++ b/api/filter/http_connection_manager.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.api.v2.filter;
 
+import "api/base.proto";
 import "api/cds.proto";
 import "api/rds.proto";
 

--- a/api/filter/http_connection_manager.proto
+++ b/api/filter/http_connection_manager.proto
@@ -1,0 +1,250 @@
+syntax = "proto3";
+
+package envoy.api.v2.filter;
+
+import "api/cds.proto";
+import "api/rds.proto";
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
+
+message Rds {
+  // The name of an upstream cluster that hosts the route discovery service. The
+  // cluster must run a service that implements the RDS API. NOTE: This is the
+  // name of a cluster defined in the cluster manager configuration, not the
+  // full definition of a cluster as in the case of SDS and CDS.
+  // TODO(htuch): Should this be simplified to an UnresolvedAddress or the like
+  // in v2 API?
+  string cluster = 1;
+
+  // The name of the route configuration. This name will be passed to the RDS
+  // API. This allows an Envoy configuration with multiple HTTP listeners (and
+  // associated HTTP connection manager filters) to use different route
+  // configurations.
+  string router_config_name = 2;
+
+  // The delay, in milliseconds, between fetches to the RDS API. Envoy will add
+  // an additional random jitter to the delay that is between zero and
+  // refresh_delay_ms milliseconds. Thus the longest possible refresh delay is 2
+  // * refresh_delay_ms. Default value is 30000ms (30 seconds).
+  google.protobuf.Duration refresh_delay = 3;
+}
+
+// Filters on HTTP response/status code.
+message StatusCodeFilter {
+  // Comparison operator.
+  enum Op {
+    EQ = 0;
+    GE = 1;
+  }
+  Op op = 1;
+
+  // Default value to compare against if runtime value is not available.
+  google.protobuf.UInt32Value value = 2;
+
+  // Runtime key to get value for comparision. This value is used if defined.
+  string runtime_key = 3;
+}
+
+// Filters on total request duration.
+message DurationFilter {
+  // Comparison operator.
+  enum Op {
+    EQ = 0;
+    GE = 1;
+  }
+  Op op = 1;
+
+  // Default value to compare against if runtime value is not available.
+  google.protobuf.Duration value = 2;
+
+  // Runtime key to get value for comparision. This value is used if defined.
+  string runtime_key = 3;
+}
+
+// Filters for requests that are not health check requests. A health check
+// request is marked by the health check filter.
+message NotHealthCheckFilter {
+}
+
+// Filters for requests that are traceable. See the tracing overview for more
+// information on how a request becomes traceable.
+message TraceableFilter {
+}
+
+// Filters for random sampling of requests. Sampling pivots on the header
+// x-request-id being present. If x-request-id is present, the filter will
+// consistently sample across multiple hosts based on the runtime key value and
+// the value extracted from x-request-id. If it is missing, the filter will
+// randomly sample based on the runtime key value.
+message RuntimeFilter {
+  // Runtime key to get the percentage of requests to be sampled. This runtime
+  // control is specified in the range 0-100 and defaults to 0.
+  string key = 1;
+}
+
+// Performs a logical “and” operation on the result of each filter in filters.
+// Filters are evaluated sequentially and if one of them returns false, the
+// filter returns false immediately.
+message AndFilter {
+  repeated AccessLogFilter filters = 1;
+}
+
+// Performs a logical “or” operation on the result of each individual filter.
+// Filters are evaluated sequentially and if one of them returns true, the
+// filter returns true immediately.
+message OrFilter {
+  repeated AccessLogFilter filters = 2;
+}
+
+message AccessLogFilter {
+  oneof filter_specifier {
+    StatusCodeFilter status_code = 1;
+    DurationFilter duration = 2;
+    NotHealthCheckFilter not_health_check = 3;
+    TraceableFilter traceable = 4;
+    RuntimeFilter runtime = 5;
+    AndFilter and = 6;
+    OrFilter or = 7;
+  }
+}
+
+message AccessLog {
+  // Path the access log is written to.
+  // TODO(dpn): Should this be a one_of and allow a remote log gRPC endpoint
+  // in conjunction with the proto access log format?
+  string path = 1;
+
+  // Access log format. Envoy supports custom access log formats as well as a
+  // default format.
+  // TODO(dpn): This needs to be given some proto structure to allow control
+  // over what gets included
+  string format = 2;
+
+  // Filter which is used to determine if the access log needs to be written.
+  AccessLogFilter filter = 3;
+}
+
+message HttpFilter {
+  // The type of filter to instantiate. Most filters implement a specific type,
+  // though it is theoretically possible for a filter to be written such that it
+  // can operate in multiple modes. Supported types are decoder, encoder, and
+  // both.
+  enum Type {
+    BOTH = 0;
+    DECODER = 1;
+    ENCODER = 2;
+  }
+  Type type = 1;
+
+  // The name of the filter to instantiate. The name must match a supported
+  // filter.
+  string name = 2;
+
+  // Filter specific configuration which depends on the filter being
+  // instantiated. See the supported filters for further documentation.
+  google.protobuf.Struct config = 3;
+}
+
+message HttpConnectionManager {
+  enum CodecType {
+    // For every new connection, the connection manager will determine which
+    // codec to use. This mode supports both ALPN for TLS listeners as well as
+    // protocol inference for plaintext listeners. If ALPN data is available, it
+    // is preferred, otherwise protocol inference is used. In almost all cases,
+    // this is the right option to choose for this setting.
+    AUTO = 0;
+    // The connection manager will assume that the client is speaking HTTP/1.1.
+    HTTP1 = 1;
+    // The connection manager will assume that the client is speaking HTTP/2
+    // (Envoy does not require HTTP/2 to take place over TLS or to use ALPN.
+    // Prior knowledge is allowed).
+    HTTP2 = 2;
+  }
+  CodecType codec_type = 1;
+
+  // The human readable prefix to use when emitting statistics for the
+  // connection manager. See the statistics documentation for more information.
+  string stat_prefix = 2;
+
+  oneof route_specifier {
+    // The connection manager’s route table will be dynamically loaded via the
+    // RDS API
+    Rds rds = 3;
+    // The route table for the connection manager is static and is specified in
+    // this property.
+    RouteConfiguration route_config = 4;
+  }
+
+  // A list of individual HTTP filters that make up the filter chain for
+  // requests made to the connection manager. Order matters as the filters are
+  // processed sequentially as request events happen.
+  repeated HttpFilter http_filters = 5;
+
+  // Whether the connection manager manipulates the user-agent and
+  // x-envoy-downstream-service-cluster headers. See the linked documentation
+  // for more information. Defaults to false.
+  google.protobuf.BoolValue add_user_agent = 6;
+
+  message Tracing {
+    // Span name will be derived from operation_name.
+    enum OperationName {
+      INGRESS = 0;
+      EGRESS = 1;
+    }
+    OperationName operation_name = 1;
+
+    // The header name is used to populate the tag name, and the header value is
+    // used to populate the tag value. The tag is created if the specified
+    // header name is present in the request’s headers.
+    repeated string request_headers_for_tags = 2;
+  }
+  Tracing tracing = 7;
+
+  // TODO(htuch): GrpcProtocolOptions?
+  oneof http_codec_options {
+    Http1ProtocolOptions http_protocol_options = 8;
+    Http2ProtocolOptions http2_protocol_options = 9;
+  }
+
+  // An optional override that the connection manager will write to the server
+  // header in responses. If not set, the default is envoy.
+  string server_name = 10;
+
+  // The idle timeout for connections managed by the connection manager. The
+  // idle timeout is defined as the period in which there are no active
+  // requests. If not set, there is no idle timeout. When the idle timeout is
+  // reached the connection will be closed. If the connection is an HTTP/2
+  // connection a drain sequence will occur prior to closing the connection. See
+  // drain_timeout.
+  google.protobuf.Duration idle_timeout = 11;
+
+  // The time that Envoy will wait between sending an HTTP/2 “shutdown
+  // notification” (GOAWAY frame with max stream ID) and a final GOAWAY frame.
+  // This is used so that Envoy provides a grace period for new streams that
+  // race with the final GOAWAY frame. During this grace period, Envoy will
+  // continue to accept new streams. After the grace period, a final GOAWAY
+  // frame is sent and Envoy will start refusing new streams. Draining occurs
+  // both when a connection hits the idle timeout or during general server
+  // draining. The default grace period is 5000 milliseconds (5 seconds) if this
+  // option is not specified.
+  google.protobuf.Duration drain_timeout = 12;
+
+  // Configuration for HTTP access logs emitted by the connection manager.
+  AccessLog access_log = 13;
+
+  // If set to true, the connection manager will use the real remote address of
+  // the client connection when determining internal versus external origin and
+  // manipulating various headers. If set to false or absent, the connection
+  // manager will use the x-forwarded-for HTTP header. See the documentation for
+  // x-forwarded-for, x-envoy-internal, and x-envoy-external-address for more
+  // information.
+  google.protobuf.BoolValue use_remote_address = 14;
+
+  // Whether the connection manager will generate the x-request-id header if it
+  // does not exist. This defaults to true. Generating a random UUID4 is
+  // expensive so in high throughput scenarios where this feature is not desired
+  // it can be disabled.
+  google.protobuf.BoolValue generate_request_id = 15;
+}

--- a/api/filter/http_connection_manager.proto
+++ b/api/filter/http_connection_manager.proto
@@ -38,11 +38,8 @@ message StatusCodeFilter {
   }
   Op op = 1;
 
-  // Default value to compare against if runtime value is not available.
-  google.protobuf.UInt32Value value = 2;
-
-  // Runtime key to get value for comparision. This value is used if defined.
-  string runtime_key = 3;
+  // Value to compare against.
+  RuntimeUInt32 value = 2;
 }
 
 // Filters on total request duration.
@@ -54,11 +51,8 @@ message DurationFilter {
   }
   Op op = 1;
 
-  // Default value to compare against if runtime value is not available.
-  google.protobuf.Duration value = 2;
-
-  // Runtime key to get value for comparision. This value is used if defined.
-  string runtime_key = 3;
+  // Value to compare against.
+  RuntimeUInt32 value = 2;
 }
 
 // Filters for requests that are not health check requests. A health check
@@ -79,7 +73,7 @@ message TraceableFilter {
 message RuntimeFilter {
   // Runtime key to get the percentage of requests to be sampled. This runtime
   // control is specified in the range 0-100 and defaults to 0.
-  string key = 1;
+  string runtime_key = 1;
 }
 
 // Performs a logical “and” operation on the result of each filter in filters.

--- a/api/filter/http_connection_manager.proto
+++ b/api/filter/http_connection_manager.proto
@@ -14,8 +14,6 @@ message Rds {
   // cluster must run a service that implements the RDS API. NOTE: This is the
   // name of a cluster defined in the cluster manager configuration, not the
   // full definition of a cluster as in the case of SDS and CDS.
-  // TODO(htuch): Should this be simplified to an UnresolvedAddress or the like
-  // in v2 API?
   string cluster = 1;
 
   // The name of the route configuration. This name will be passed to the RDS
@@ -240,6 +238,8 @@ message HttpConnectionManager {
   // manager will use the x-forwarded-for HTTP header. See the documentation for
   // x-forwarded-for, x-envoy-internal, and x-envoy-external-address for more
   // information.
+  // TODO(mattklein123): Clean this up, see also discussion in
+  // https://github.com/lyft/envoy/issues/794.
   google.protobuf.BoolValue use_remote_address = 14;
 
   // Whether the connection manager will generate the x-request-id header if it

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -94,23 +94,16 @@ message RouteMatch {
   // is true.
   google.protobuf.BoolValue case_sensitive = 3;
 
+  // Indicates that the route should additionally match on a runtime key. An
+  // integer between 0-100. Every time the route is considered for a match, a
+  // random number between 0-99 is selected. If the number is <= the value found
+  // in the key (checked first) or, if the key is not present, the default
+  // value, the route is a match (assuming everything also about the route
+  // matches).
   // A runtime route configuration can be used to roll out route changes in a
   // gradual manner without full code/config deploys. Refer to traffic shifting
   // docs for additional documentation.
-  message Runtime {
-    // Specifies the runtime key name that should be consulted to determine
-    // whether the route matches or not. See the runtime documentation for how
-    // key names map to the underlying implementation.
-    string key = 1;
-    // An integer between 0-100. Every time the route is considered for a match,
-    // a random number between 0-99 is selected. If the number is <= the value
-    // found in the key (checked first) or, if the key is not present, the
-    // default value, the route is a match (assuming everything also about the
-    // route matches).
-    google.protobuf.UInt32Value default_value = 2;
-  }
-  // Indicates that the route should additionally match on a runtime key.
-  Runtime runtime = 4;
+  RuntimeUInt32 runtime = 4;
 
   // Specifies a set of headers that the route should match on. The router will
   // check the request’s headers against all the specified headers in the route


### PR DESCRIPTION
This is the first example of a network filter proto. Later patches will supply code to convert to google.protobuf.Struct and merge with LDS protos.