### PR TITLE
TLS: add ability to hash SPKI instead of certificate.

### DIFF
--- a/api/tls_context.proto
+++ b/api/tls_context.proto
@@ -46,9 +46,10 @@ message CertificateValidationContext {
   // presented it will not be verified.
   DataSource ca_cert = 1;
 
-  // If specified, Envoy will verify (pin) the hash of the presented
-  // certificate.
-  repeated string verify_certificate_hash = 2;
+  // If specified, Envoy will verify (pin) base64-encoded SHA-256 hash of
+  // the Subject Public Key Information (SPKI) of the presented certificate.
+  // This is the same format as used in HTTP Public Key Pinning.
+  repeated string verify_spki_sha256 = 2;
 
   // An optional list of subject alt names. If specified, Envoy will verify that
   // the certificate’s subject alt name matches one of the specified values.

--- a/api/tls_context.proto
+++ b/api/tls_context.proto
@@ -46,20 +46,24 @@ message CertificateValidationContext {
   // presented it will not be verified.
   DataSource ca_cert = 1;
 
+  // If specified, Envoy will verify (pin) hex-encoded SHA-256 hash of
+  // the presented certificate.
+  repeated string verify_certificate_hash = 2;
+
   // If specified, Envoy will verify (pin) base64-encoded SHA-256 hash of
   // the Subject Public Key Information (SPKI) of the presented certificate.
   // This is the same format as used in HTTP Public Key Pinning.
-  repeated string verify_spki_sha256 = 2;
+  repeated string verify_spki_sha256 = 3;
 
   // An optional list of subject alt names. If specified, Envoy will verify that
   // the certificate’s subject alt name matches one of the specified values.
-  repeated string verify_subject_alt_name = 3;
+  repeated string verify_subject_alt_name = 4;
 
   // Must present a signed time-stamped OCSP response.
-  google.protobuf.BoolValue require_ocsp_staple = 4;
+  google.protobuf.BoolValue require_ocsp_staple = 5;
 
   // Must present signed certificate time-stamp.
-  google.protobuf.BoolValue require_signed_certificate_timestamp = 5;
+  google.protobuf.BoolValue require_signed_certificate_timestamp = 6;
 }
 
 message UpstreamTlsContext {


### PR DESCRIPTION
SPKI doesn't change when certificate is reissued, so it works better
with short-lived certificates.

This is also the same format as used in HTTP Public Key Pinning.