### PR TITLE
lds: prefix ranges and source IP/port matching.

### DIFF
--- a/api/lds.proto
+++ b/api/lds.proto
@@ -65,7 +65,7 @@ message FilterChainMatch {
   repeated string sni_domains = 1;
 
   // If non-empty, an IP address and prefix length to match addresses when the
-  // listener is bound to 0.0.0.0/::.
+  // listener is bound to 0.0.0.0/:: or when use_original_dst is specified.
   message CidrRange {
     string address_prefix = 1;
     google.protobuf.UInt32Value prefix_len = 2;
@@ -73,7 +73,7 @@ message FilterChainMatch {
   repeated CidrRange prefix_ranges = 3;
 
   // If non-empty, an IP address and suffix length to match addresses when the
-  // listener is bound to 0.0.0.0/::.
+  // listener is bound to 0.0.0.0/:: or when use_original_dst is specified.
   string address_suffix = 4;
   google.protobuf.UInt32Value suffix_len = 5;
 
@@ -130,26 +130,16 @@ message Listener {
   //    select the FilterChain from step 2 that is used.
   repeated FilterChain filter_chains = 2;
 
-  // Whether the listener should not bind to the port. A listener that doesn’t bind
-  // can only receive connections redirected from other listeners that set
-  // use_origin_dst parameter to true. Default is true.
-  google.protobuf.BoolValue bind_to_port = 3;
-
   // If a connection is redirected using iptables, the port on which the proxy
   // receives it might be different from the original destination port. When
-  // this flag is set to true, the listener hands off redirected connections to
-  // the listener associated with the original destination port. If there is no
-  // listener associated with the original destination port, the connection is
-  // handled by the listener that receives it. Default is false.
-  // TODO(htuch): Clarify how use_original_dst interacts with listeners that
-  // bind to specific IP addresses, where we want the original destination IP to
-  // be used in the FilterChainMatch but not on bind.
-  google.protobuf.BoolValue use_original_dst = 4;
+  // this flag is set to true, the listener uses the original destination
+  // address and port during FilterChain matching. Default is false.
+  google.protobuf.BoolValue use_original_dst = 3;
 
   // Soft limit on size of the listener’s new connection read and write buffers.
   // If unspecified, an implementation defined default is applied (1MiB).
-  google.protobuf.UInt32Value per_connection_buffer_limit_bytes = 5;
+  google.protobuf.UInt32Value per_connection_buffer_limit_bytes = 4;
 
   // See base.Metadata description.
-  Metadata metadata = 6;
+  Metadata metadata = 5;
 }

--- a/api/lds.proto
+++ b/api/lds.proto
@@ -66,13 +66,27 @@ message FilterChainMatch {
 
   // If non-empty, an IP address and prefix length to match addresses when the
   // listener is bound to 0.0.0.0/::.
-  string address_prefix = 2;
-  google.protobuf.UInt32Value prefix_len = 3;
+  message CidrRange {
+    string address_prefix = 1;
+    google.protobuf.UInt32Value prefix_len = 2;
+  }
+  repeated CidrRange prefix_ranges = 3;
 
   // If non-empty, an IP address and suffix length to match addresses when the
   // listener is bound to 0.0.0.0/::.
   string address_suffix = 4;
   google.protobuf.UInt32Value suffix_len = 5;
+
+  // The criteria is satisfied if the source IP address of the downstream
+  // connection is contained in at least one of the specified subnets. If the
+  // parameter is not specified or the list is empty, the source IP address is
+  // ignored.
+  repeated CidrRange source_prefix_ranges = 6;
+
+  // The criteria is satisfied if the source port of the downstream connection
+  // is contained in at least one of the specified ports. If the parameter is
+  // not specified, the source port is ignored.
+  repeated google.protobuf.UInt32Value source_ports = 7;
 }
 
 // Grouping of FilterChainMatch criteria, DownstreamTlsContext, the actual filter chain


### PR DESCRIPTION
* Allow multiple CIDR ranges to be provided for the prefix match. This
  is useful when you have the same listener config in multiple subnets,
  each subnet with the same suffix allocation of VIPs and the CIDR prefix
  assigned by region/zone, e.g. when using the GCP subnetworks feature.
  E.g. the service is on 0.0.0.37 in subnetworks 10.1.0.0 in US and
  10.2.0.0 in Asia.

* Add source IP/port matching similar to existing TCP proxy filter. This
  moves the route configuration from the TCP proxy filter to the
  FilterChainMatch, making it also available to HTTP connections.

Fixes #6 and #36.