### PR TITLE
api/filter: add tcp_proxy/rate_limit/mongo_proxy filter config protos.

### DIFF
--- a/api/filter/BUILD
+++ b/api/filter/BUILD
@@ -9,3 +9,18 @@ api_proto_library(
         "//api:rds",
     ],
 )
+
+api_proto_library(
+    name = "mongo_proxy",
+    srcs = ["mongo_proxy.proto"],
+)
+
+api_proto_library(
+    name = "rate_limit",
+    srcs = ["rate_limit.proto"],
+)
+
+api_proto_library(
+    name = "tcp_proxy",
+    srcs = ["tcp_proxy.proto"],
+)

--- a/api/filter/mongo_proxy.proto
+++ b/api/filter/mongo_proxy.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package envoy.api.v2.filter;
+
+message MongoProxy {
+  // The human readable prefix to use when emitting statistics for the
+  // MongoDB proxy filter. See the statistics documentation for more information.
+  string stat_prefix = 1;
+
+  // The optional path to use for writing Mongo access logs. If not access log
+  // path is specified no access logs will be written. Note that access log is
+  // also gated by runtime.
+  string access_log = 2;
+}

--- a/api/filter/rate_limit.proto
+++ b/api/filter/rate_limit.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package envoy.api.v2.filter;
+
+message RateLimit {
+  // The human readable prefix to use when emitting statistics for the
+  // rate limit filter. See the statistics documentation for more information.
+  string stat_prefix = 1;
+
+  // The rate limit domain to use in the rate limit service request.
+  string domain = 2;
+
+  // The rate limit descriptor list to use in the rate limit service request.
+  // TODO(htuch): This should be the shared canonical RateLimitDescriptor when
+  // we import the rate limit protos
+  // (https://github.com/lyft/envoy-api/issues/26).
+  message RateLimitDescriptor {
+    message Entry {
+      string key = 1;
+      string value = 2;
+    }
+    repeated Entry entries = 1;
+  }
+  repeated RateLimitDescriptor rate_limit_descriptors = 3;
+}

--- a/api/filter/tcp_proxy.proto
+++ b/api/filter/tcp_proxy.proto
@@ -11,11 +11,15 @@ message TcpProxy {
   string stat_prefix = 1;
 
   // The upstream cluster to connect to.
+  // TODO(htuch): look into shared WeightedCluster support with RDS.
   string cluster = 2;
 
   // [V2-API-DIFF] The idle timeout for connections managed by the TCP proxy
   // filter. The idle timeout is defined as the period in which there is no
   // active traffic. If not set, there is no idle timeout. When the idle timeout
-  // is reached the connection will be closed.
-  google.protobuf.Duration idle_timeout = 11;
+  // is reached the connection will be closed. The distinction between
+  // downstream_idle_timeout/upstream_idle_timeout provides a means to set
+  // timeout based on the last byte sent on the downstream/upstream connection.
+  google.protobuf.Duration downstream_idle_timeout = 3;
+  google.protobuf.Duration upstream_idle_timeout = 4;
 }

--- a/api/filter/tcp_proxy.proto
+++ b/api/filter/tcp_proxy.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package envoy.api.v2.filter;
+
+import "google/protobuf/duration.proto";
+
+// [V2-API-DIFF] The route match now takes place in the FilterChainMatch table.
+message TcpProxy {
+  // The human readable prefix to use when emitting statistics for the
+  // TCP proxy filter. See the statistics documentation for more information.
+  string stat_prefix = 1;
+
+  // The upstream cluster to connect to.
+  string cluster = 2;
+
+  // [V2-API-DIFF] The idle timeout for connections managed by the TCP proxy
+  // filter. The idle timeout is defined as the period in which there is no
+  // active traffic. If not set, there is no idle timeout. When the idle timeout
+  // is reached the connection will be closed.
+  google.protobuf.Duration idle_timeout = 11;
+}


### PR DESCRIPTION
TCP proxy filter now has an idle timeout and the source match (and rest
of route match as well) are now in the FilterChainMatch in
https://github.com/lyft/envoy-api/pull/49.

Fixes #23, #45.