### PR TITLE
rds/cds: allow future extension of upstream priorities.

### DIFF
--- a/api/base.proto
+++ b/api/base.proto
@@ -53,3 +53,14 @@ message RuntimeUInt32 {
   // Runtime key to get value for comparision. This value is used if defined.
   string runtime_key = 3;
 }
+
+// Envoy supports upstream priority routing both at the route and the virtual
+// cluster level. The current priority implementation uses different connection
+// pool and circuit breaking settings for each priority level. This means that
+// even for HTTP/2 requests, two physical connections will be used to an
+// upstream host. In the future Envoy will likely support true HTTP/2 priority
+// over a single upstream connection.
+enum RoutingPriority {
+  DEFAULT = 0;
+  HIGH = 1;
+}

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -38,26 +38,25 @@ message ClusterDiscoveryResponse {
 // priority.
 message CircuitBreakers {
   message Thresholds {
+    RoutingPriority priority = 1;
     // The maximum number of connections that Envoy will make to the upstream
     // cluster. If not specified, the default is 1024. See the circuit
     // breaking overview for more information.
-    google.protobuf.UInt32Value max_connections = 1;
+    google.protobuf.UInt32Value max_connections = 2;
     // The maximum number of pending requests that Envoy will allow to the
     // upstream cluster. If not specified, the default is 1024. See the circuit
     // breaking overview for more information.
-    google.protobuf.UInt32Value max_pending_requests = 2;
+    google.protobuf.UInt32Value max_pending_requests = 3;
     // The maximum number of parallel requests that Envoy will make to the
     // upstream cluster. If not specified, the default is 1024. See the circuit
     // breaking overview for more information.
-    google.protobuf.UInt32Value max_requests = 3;
+    google.protobuf.UInt32Value max_requests = 4;
     // The maximum number of parallel retries that Envoy will allow to the
     // upstream cluster. If not specified, the default is 3. See the circuit
     // breaking overview for more information.
-    google.protobuf.UInt32Value max_retries = 4;
+    google.protobuf.UInt32Value max_retries = 5;
   }
-
-  Thresholds default_priority = 1;
-  Thresholds high_priority = 2;
+  repeated Thresholds thresholds = 1;
 }
 
 

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -40,17 +40,6 @@ message RouteDiscoveryResponse {
   RouteConfiguration route_table = 1;
 }
 
-// Envoy supports priority routing both at the route and the virtual cluster
-// level. The current priority implementation uses different connection pool
-// and circuit breaking settings for each priority level. This means that even
-// for HTTP/2 requests, two physical connections will be used to an upstream
-// host. In the future Envoy will likely support true HTTP/2 priority over a
-// single connection.
-enum RoutingPriority {
-  DEFAULT = 0;
-  HIGH = 1;
-}
-
 // Compared to the cluster field that specifies a single upstream cluster as the
 // target of a request, the weighted_clusters option allows for specification of
 // multiple upstream clusters along with weights that indicate the percentage of


### PR DESCRIPTION
While still supporting only 2 priorities today, this PR leaves room for
an additional finite number of priorities via enum extension. Since
we're not planning on reflecting arbitrary downstream priorities in the
upstream connection, we only expect a small number of priorities to be
useful in configuring routes and clusters.

Fixes #1.