### PR TITLE
TLS: add support for password-protected private keys.

### DIFF
--- a/api/tls_context.proto
+++ b/api/tls_context.proto
@@ -34,10 +34,11 @@ message TlsParameters {
 // TLS certs can be loaded from file or delivered inline [V2-API-DIFF]. Individual fields may
 // be loaded from either.
 message TlsCertificate {
-  DataSource cert_chain = 1;
+  DataSource certificate_chain = 1;
   DataSource private_key = 2;
-  DataSource ocsp_staple = 3;
-  repeated DataSource signed_certificate_timestamp = 4;
+  DataSource password = 3;
+  DataSource ocsp_staple = 4;
+  repeated DataSource signed_certificate_timestamp = 5;
 }
 
 message CertificateValidationContext {


### PR DESCRIPTION
While there, rename "cert_chain" to "certificate_chain", since
we're using the full word in rest of the API.