### PR TITLE
Export protobuf sources as filegroup

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -19,7 +19,8 @@ filegroup(
 cc_proto_library(
     name = "http_api_protos",
     srcs = [
-        ":http_apis_protos_src",
+        "google/api/annotations.proto",
+        "google/api/http.proto",
     ],
     default_runtime = "//external:protobuf",
     protoc = "//external:protoc",
@@ -30,7 +31,8 @@ cc_proto_library(
 py_proto_library(
     name = "http_api_protos_py",
     srcs = [
-        ":http_apis_protos_src",
+        "google/api/annotations.proto",
+        "google/api/http.proto",
     ],
     include = ".",
     default_runtime = "//external:protobuf_python",

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -7,11 +7,19 @@ def api_dependencies():
         build_file_content = """
 load("@protobuf_bzl//:protobuf.bzl", "cc_proto_library", "py_proto_library")
 
-cc_proto_library(
-    name = "http_api_protos",
+filegroup(
+    name = "http_api_protos_src",
     srcs = [
         "google/api/annotations.proto",
         "google/api/http.proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "http_api_protos",
+    srcs = [
+        ":http_apis_protos_src",
     ],
     default_runtime = "//external:protobuf",
     protoc = "//external:protoc",
@@ -22,8 +30,7 @@ cc_proto_library(
 py_proto_library(
     name = "http_api_protos_py",
     srcs = [
-        "google/api/annotations.proto",
-        "google/api/http.proto",
+        ":http_apis_protos_src",
     ],
     include = ".",
     default_runtime = "//external:protobuf_python",


### PR DESCRIPTION
The source files needed for descriptor generation, at https://github.com/lizan/envoy/blob/aa3aada1fa9e2557e34c1144d91bb2241da84ebf/test/proto/BUILD#L24 in lyft/envoy#1079