### PR TITLE
api: generalize DiscoveryResponse and some versioning updates.

### DIFF
--- a/api/base.proto
+++ b/api/base.proto
@@ -4,6 +4,7 @@ package envoy.api.v2;
 
 import "api/address.proto";
 
+import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -94,11 +95,19 @@ message HeaderValueOption {
 message DiscoveryRequest {
   // The version_info provided in the request messages will be the version_info
   // received with the most recent successfully processed response or empty on
-  // the first request.
-  bytes version_info = 1;
+  // the first request. It is expected that no new request is sent after a
+  // response is received until the Envoy instance is ready to ACK/NACK the new
+  // configuration. ACK/NACK takes place by returning the new API config version
+  // as applied or the previous API config version respectively.
+  string version_info = 1;
   Node node = 2;
   // List of resources to subscribe to, e.g. list of cluster names or a route
   // configuration name. If this is empty, all resources for the API are
   // returned.
   repeated string resource_names = 3;
+}
+
+message DiscoveryResponse {
+  string version_info = 1;
+  repeated google.protobuf.Any resources = 2;
 }

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -16,21 +16,16 @@ option cc_generic_services = true;
 // Return list of all clusters this proxy will load balance to.
 service ClusterDiscoveryService {
   rpc StreamClusters(stream DiscoveryRequest)
-      returns (stream ClusterDiscoveryResponse) {
+      returns (stream DiscoveryResponse) {
   }
 
   rpc FetchClusters(DiscoveryRequest)
-      returns (ClusterDiscoveryResponse) {
+      returns (DiscoveryResponse) {
     option (google.api.http) = {
       post: "/v2/discovery:clusters"
       body: "*"
     };
   }
-}
-
-message ClusterDiscoveryResponse {
-  bytes version_info = 1;
-  repeated Cluster resources = 2;
 }
 
 // Circuit breaking settings can be specified individually for each defined

--- a/api/eds.proto
+++ b/api/eds.proto
@@ -15,11 +15,11 @@ service EndpointDiscoveryService {
   // The resource_names field in DiscoveryRequest specifies a list of clusters
   // to subscribe to updates for.
   rpc StreamEndpoints(stream DiscoveryRequest)
-      returns (stream EndpointDiscoveryResponse) {
+      returns (stream DiscoveryResponse) {
   }
 
   rpc FetchEndpoints(DiscoveryRequest)
-      returns (EndpointDiscoveryResponse) {
+      returns (DiscoveryResponse) {
     option (google.api.http) = {
       post: "/v2/discovery:endpoints"
       body: "*"
@@ -102,11 +102,6 @@ message LocalityLbEndpoints {
   // instead use the sum of all weights in the denominator when computing
   // effective the weight ratio as done in v1?
   google.protobuf.UInt32Value load_balancing_weight = 3;
-}
-
-message EndpointDiscoveryResponse {
-  bytes version_info = 1;
-  repeated ClusterLoadAssignment resources = 2;
 }
 
 // Example load report from a single request:

--- a/api/lds.proto
+++ b/api/lds.proto
@@ -22,21 +22,16 @@ option cc_generic_services = true;
 // allowed to drain from listeners that are no longer present.
 service ListenerDiscoveryService {
   rpc StreamListeners(stream DiscoveryRequest)
-      returns (stream ListenerDiscoveryResponse) {
+      returns (stream DiscoveryResponse) {
   }
 
   rpc FetchListeners(DiscoveryRequest)
-      returns (ListenerDiscoveryResponse) {
+      returns (DiscoveryResponse) {
     option (google.api.http) = {
       post: "/v2/discovery:listeners"
       body: "*"
     };
   }
-}
-
-message ListenerDiscoveryResponse {
-  bytes version_info = 1;
-  repeated Listener resources = 2;
 }
 
 message Filter {

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -21,21 +21,16 @@ option cc_generic_services = true;
 // a route table via this identifier.
 service RouteDiscoveryService {
   rpc StreamRoutes(stream DiscoveryRequest)
-      returns (stream RouteDiscoveryResponse) {
+      returns (stream DiscoveryResponse) {
   }
 
   rpc FetchRoutes(DiscoveryRequest)
-      returns (RouteDiscoveryResponse) {
+      returns (DiscoveryResponse) {
     option (google.api.http) = {
       post: "/v2/discovery:routes"
       body: "*"
     };
   }
-}
-
-message RouteDiscoveryResponse {
-  bytes version_info = 1;
-  repeated RouteConfiguration resources = 2;
 }
 
 // Compared to the cluster field that specifies a single upstream cluster as the


### PR DESCRIPTION
* Factor all subscription responses to DiscoveryResponse message with an Any
  resource type. This further simplifies the Subscription interface in
  the Envoy client, as it no longer needs to be templatized on the
  response type.

* Replace version_info bytes type with string. This allows plain
  strings to be used in JSON representations rather than base64 encoded
  strings as required in the canonical proto3 translation of bytes.

* Clarify ACK/NACK semantics with version_info in comments.

Fixes #85.