### PR TITLE
test/api: basic C++ build/link test, minor RLDS fix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 matrix:
   fast_finish: true
 env:
-  - TEST_TYPE=bazel.build
+  - TEST_TYPE=bazel.test
 script: ./ci/ci_steps.sh
 
 branches:

--- a/api/rlds.proto
+++ b/api/rlds.proto
@@ -61,26 +61,26 @@ message RateLimitDescriptor {
   repeated Entry entries = 1;
 }
 
-// Defines an actual rate limit in terms of requests per unit of time and the unit itself.
-message RateLimit {
-  enum Unit {
-    UNKNOWN = 0;
-    SECOND  = 1;
-    MINUTE  = 2;
-    HOUR    = 3;
-    DAY     = 4;
-  }
-
-  uint32 requests_per_unit = 1;
-  Unit unit = 2;
-}
-
 // A response from a ShouldRateLimit call.
 message RateLimitResponse {
   enum Code {
     UNKNOWN = 0;
     OK = 1;
     OVER_LIMIT = 2;
+  }
+
+  // Defines an actual rate limit in terms of requests per unit of time and the unit itself.
+  message RateLimit {
+    enum Unit {
+      UNKNOWN = 0;
+      SECOND  = 1;
+      MINUTE  = 2;
+      HOUR    = 3;
+      DAY     = 4;
+    }
+
+    uint32 requests_per_unit = 1;
+    Unit unit = 2;
   }
 
   message DescriptorStatus {

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -8,9 +8,10 @@ set -e
 
 echo "building using ${NUM_CPUS} CPUs"
 
-if [[ "$1" == "bazel.build" ]]; then
-  echo "bazel build..."
+if [[ "$1" == "bazel.test" ]]; then
+  echo "bazel building and testing..."
   bazel --batch build ${BAZEL_BUILD_OPTIONS} //...
+  bazel --batch test ${BAZEL_TEST_OPTIONS} //...
   exit 0
 else
   echo "Invalid do_ci.sh target. The only valid target is bazel.build."

--- a/test/build/BUILD
+++ b/test/build/BUILD
@@ -1,0 +1,12 @@
+cc_test(
+    name = "build_test",
+    srcs = ["build_test.cc"],
+    deps = [
+        "//api:cds",
+        "//api:eds",
+        "//api:hds",
+        "//api:lds",
+        "//api:rlds",
+        "//api:rds",
+    ],
+)

--- a/test/build/build_test.cc
+++ b/test/build/build_test.cc
@@ -1,0 +1,16 @@
+#include "api/cds.pb.h"
+#include "api/eds.pb.h"
+#include "api/hds.pb.h"
+#include "api/lds.pb.h"
+#include "api/rlds.pb.h"
+#include "api/rds.pb.h"
+
+// Basic C++ build/link validation for the v2 xDS APIs.
+int main(int argc, char *argv[]) {
+  envoy::api::v2::ClusterDiscoveryService::descriptor();
+  envoy::api::v2::EndpointDiscoveryService::descriptor();
+  envoy::api::v2::HealthDiscoveryService::descriptor();
+  envoy::api::v2::ListenerDiscoveryService::descriptor();
+  envoy::api::v2::RateLimitDiscoveryService::descriptor();
+  envoy::api::v2::RouteDiscoveryService::descriptor();
+}


### PR DESCRIPTION
This is useful in Travis CI (and also internally at Google in our CI) to
validate basic build/link of the protos.

This exposed a small issue with API compatibility. Since we don't have
additional package namespaces for each individual API, there was a
conflict between the RateLimit mesage in RLDS and RDS. The quick fix was
to move the RLDS message inside the response object (this is fine as
nobody is using the v2 RLDS yet, open to alternatives including per-xDS
API namespaces).