### PR TITLE
eds/rds: endpoint subsetting in clusters based on metadata.

### DIFF
--- a/api/accesslog.proto
+++ b/api/accesslog.proto
@@ -145,12 +145,14 @@ message EnvoyAccessLog {
   // Original Path from the X-Envoy-Original-Path header.
   string original_path = 24;
 
-  // Metadata in the envoy.http_connection_manager.access_log namespace
+  // All metadata encountered during request processing, including endpoint
+  // selection.
   //
   // This can be used to associate IDs attached to the various configurations
   // used to process this request with the access log entry.  For example, a
   // route created from a higher level forwarding rule with some ID can place
-  // that ID in this field and cross reference later.
+  // that ID in this field and cross reference later. It can also be used to
+  // determine if a canary endpoint was used or not.
   google.protobuf.Struct metadata = 25;
 
   // Headers configured for logging but not covered by a specific field.

--- a/api/base.proto
+++ b/api/base.proto
@@ -42,6 +42,14 @@ message Endpoint {
 // An example use of metadata is providing additional values to
 // http_connection_manager in the envoy.http_connection_manager.access_log
 // namespace.
+//
+// For load balancing, Metadata provides a means to canary subset endpoints.
+// Endpoints have a Metadata object associated and routes contain a Metadata
+// object to match against. There are some well defined metadata used today for
+// this purpose:
+// - {"envoy.lb": {"canary": <bool> }}. This indicates the canary status of an
+//   endpoint and is used during header processing (x-envoy-upstream-canary) and
+//   for stats purposes.
 message Metadata {
   // Key is the reverse DNS filter name.
   map<string, google.protobuf.Struct> filter_metadata = 1;

--- a/api/base.proto
+++ b/api/base.proto
@@ -43,13 +43,13 @@ message Endpoint {
 // http_connection_manager in the envoy.http_connection_manager.access_log
 // namespace.
 //
-// For load balancing, Metadata provides a means to canary subset endpoints.
+// For load balancing, Metadata provides a means to subset cluster endpoints.
 // Endpoints have a Metadata object associated and routes contain a Metadata
 // object to match against. There are some well defined metadata used today for
 // this purpose:
 // - {"envoy.lb": {"canary": <bool> }}. This indicates the canary status of an
-//   endpoint and is used during header processing (x-envoy-upstream-canary) and
-//   for stats purposes.
+//   endpoint and is also used during header processing
+//   (x-envoy-upstream-canary) and for stats purposes.
 message Metadata {
   // Key is the reverse DNS filter name.
   map<string, google.protobuf.Struct> filter_metadata = 1;

--- a/api/base.proto
+++ b/api/base.proto
@@ -34,10 +34,10 @@ message Endpoint {
 }
 
 // Metadata provides additional inputs to filters based on matched listeners,
-// filter chains and routes. It is structured as a map from filter name (in
-// reverse DNS format) to metadata specific to the filter. Metadata key-values
-// for a filter are merged as connection and request handling occurs, with later
-// values for the same key overriding earlier values.
+// filter chains, routes and endpoints. It is structured as a map from filter
+// name (in reverse DNS format) to metadata specific to the filter. Metadata
+// key-values for a filter are merged as connection and request handling occurs,
+// with later values for the same key overriding earlier values.
 //
 // An example use of metadata is providing additional values to
 // http_connection_manager in the envoy.http_connection_manager.access_log

--- a/api/eds.proto
+++ b/api/eds.proto
@@ -74,10 +74,16 @@ message LbEndpoint {
   // Optional health status when known and supplied by EDS server.
   HealthStatus health_status = 2;
 
-  // The optional canary status of the upstream host. Envoy uses the canary
-  // status for various statistics and load balancing tasks documented
-  // elsewhere.
-  google.protobuf.BoolValue canary = 3;
+  // The endpoint metadata specifies values that may be used by the load
+  // balancer to select endpoints in a cluster for a given request. The filter
+  // name should be specified as "envoy.lb". An example boolean key-value pair
+  // is "canary", providing the optional canary status of the upstream host.
+  // This may be matched against in a route's ForwardAction metadata_match field
+  // to subset the endpoints considered in cluster load balancing.
+  // TODO(htuch: [V2-API-DIFF] Need to plumb this through Envoy and have
+  // everywhere that canary is used be capable of working on metadata.
+  Metadata metadata = 3;
+
   // The optional load balancing weight of the upstream host, in the range 1 -
   // 100. Envoy uses the load balancing weight in some of the built in load
   // balancers. All load balancing weights in a locality must sum to 100%.

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -47,6 +47,10 @@ message WeightedCluster {
     // an upstream cluster is determined by its weight. The sum of weights
     // across all entries in the clusters array must add up to 100.
     google.protobuf.UInt32Value weight = 2;
+    // Optional endpoint metadata match criteria. Only endpoints in the upstream
+    // cluster with metadata matching that set in metadata_match will be
+    // considered. The filter name should be specified as "envoy.lb".
+    Metadata metadata_match = 3;
   }
   // Specifies one or more upstream clusters associated with the route.
   repeated ClusterWeight clusters = 1;
@@ -116,27 +120,32 @@ message ForwardAction {
     WeightedCluster weighted_clusters = 3;
   }
 
+  // Optional endpoint metadata match criteria. Only endpoints in the upstream
+  // cluster with metadata matching that set in metadata_match will be
+  // considered. The filter name should be specified as "envoy.lb".
+  Metadata metadata_match = 4;
+
   // Indicates that during forwarding, the matched prefix (or path) should be
   // swapped with this value. This option allows application URLs to be rooted
   // at a different path from those exposed at the reverse proxy layer.
-  string prefix_rewrite = 4;
+  string prefix_rewrite = 5;
   oneof host_rewrite_specifier {
     // Indicates that during forwarding, the host header will be swapped with
     // this value.
-    string host_rewrite = 5;
+    string host_rewrite = 6;
     // Indicates that during forwarding, the host header will be swapped with
     // the hostname of the upstream host chosen by the cluster manager. This
     // option is applicable only when the destination cluster for a route is of
     // type strict_dns or logical_dns. Setting this to true with other cluster
     // types has no effect.
-    google.protobuf.BoolValue auto_host_rewrite = 6;
+    google.protobuf.BoolValue auto_host_rewrite = 7;
   }
 
   // Specifies the timeout for the route. If not specified, the default is 15s.
   // Note that this timeout includes all retries. See also
   // x-envoy-upstream-rq-timeout-ms, x-envoy-upstream-rq-per-try-timeout-ms, and
   // the retry overview.
-  google.protobuf.Duration timeout = 7;
+  google.protobuf.Duration timeout = 8;
 
   message RetryPolicy {
     // Specifies the conditions under which retry takes place. These are the
@@ -152,7 +161,7 @@ message ForwardAction {
     google.protobuf.Duration per_try_timeout = 3;
   }
   // Indicates that the route has a retry policy.
-  RetryPolicy retry_policy = 8;
+  RetryPolicy retry_policy = 9;
 
   // Indicates that the route has a request mirroring policy.
   message RequestMirrorPolicy {
@@ -167,22 +176,22 @@ message ForwardAction {
     // requests will be mirrored.
     string runtime_key = 2;
   }
-  RequestMirrorPolicy request_mirror_policy = 9;
+  RequestMirrorPolicy request_mirror_policy = 10;
 
-  RoutingPriority priority = 10;
+  RoutingPriority priority = 11;
 
   // Specifies a set of headers that will be added to requests matching this
   // route.
-  repeated HeaderValueOption request_headers_to_add = 11;
+  repeated HeaderValueOption request_headers_to_add = 12;
 
   // Specifies a set of rate limit configurations that could be applied to the
   // route.
-  repeated RateLimit rate_limits = 12;
+  repeated RateLimit rate_limits = 13;
 
   // Specifies if the rate limit filter should include the virtual host rate
   // limits. By default, if the route configured rate limits, the virtual host
   // rate_limits are not applied to the request.
-  google.protobuf.BoolValue include_vh_rate_limits = 13;
+  google.protobuf.BoolValue include_vh_rate_limits = 14;
 
   message HashPolicy {
     // [V2-API-DIFF] We expect additional hash policies in the future, e.g.
@@ -198,7 +207,7 @@ message ForwardAction {
       Header header = 1;
     }
   }
-  repeated HashPolicy hash_policy = 14;
+  repeated HashPolicy hash_policy = 15;
 }
 
 message RedirectAction {

--- a/test/build/build_test.cc
+++ b/test/build/build_test.cc
@@ -1,3 +1,6 @@
+#include <iostream>
+#include <cstdlib>
+
 #include "api/cds.pb.h"
 #include "api/eds.pb.h"
 #include "api/hds.pb.h"
@@ -7,10 +10,26 @@
 
 // Basic C++ build/link validation for the v2 xDS APIs.
 int main(int argc, char *argv[]) {
-  envoy::api::v2::ClusterDiscoveryService::descriptor();
-  envoy::api::v2::EndpointDiscoveryService::descriptor();
-  envoy::api::v2::HealthDiscoveryService::descriptor();
-  envoy::api::v2::ListenerDiscoveryService::descriptor();
-  envoy::api::v2::RateLimitDiscoveryService::descriptor();
-  envoy::api::v2::RouteDiscoveryService::descriptor();
+  const auto methods = {
+    "envoy.api.v2.ClusterDiscoveryService.FetchClusters",
+    "envoy.api.v2.ClusterDiscoveryService.StreamClusters",
+    "envoy.api.v2.EndpointDiscoveryService.FetchEndpoints",
+    "envoy.api.v2.EndpointDiscoveryService.StreamEndpoints",
+    "envoy.api.v2.HealthDiscoveryService.FetchHealthCheck",
+    "envoy.api.v2.HealthDiscoveryService.StreamHealthCheck",
+    "envoy.api.v2.ListenerDiscoveryService.FetchListeners",
+    "envoy.api.v2.ListenerDiscoveryService.StreamListeners",
+    "envoy.api.v2.RouteDiscoveryService.FetchRoutes",
+    "envoy.api.v2.RouteDiscoveryService.StreamRoutes",
+    "envoy.api.v2.RateLimitDiscoveryService.ShouldRateLimit",
+  };
+
+  for (const auto& method : methods) {
+    if (google::protobuf::DescriptorPool::generated_pool()->FindMethodByName(method) == nullptr) {
+      std::cout << "Unable to find method descriptor for " << method << std::endl;
+      exit(EXIT_FAILURE);
+    }
+  }
+
+  exit(EXIT_SUCCESS);
 }

--- a/test/build/build_test.cc
+++ b/test/build/build_test.cc
@@ -1,6 +1,3 @@
-#include <iostream>
-#include <cstdlib>
-
 #include "api/cds.pb.h"
 #include "api/eds.pb.h"
 #include "api/hds.pb.h"
@@ -10,26 +7,10 @@
 
 // Basic C++ build/link validation for the v2 xDS APIs.
 int main(int argc, char *argv[]) {
-  const auto methods = {
-    "envoy.api.v2.ClusterDiscoveryService.FetchClusters",
-    "envoy.api.v2.ClusterDiscoveryService.StreamClusters",
-    "envoy.api.v2.EndpointDiscoveryService.FetchEndpoints",
-    "envoy.api.v2.EndpointDiscoveryService.StreamEndpoints",
-    "envoy.api.v2.HealthDiscoveryService.FetchHealthCheck",
-    "envoy.api.v2.HealthDiscoveryService.StreamHealthCheck",
-    "envoy.api.v2.ListenerDiscoveryService.FetchListeners",
-    "envoy.api.v2.ListenerDiscoveryService.StreamListeners",
-    "envoy.api.v2.RouteDiscoveryService.FetchRoutes",
-    "envoy.api.v2.RouteDiscoveryService.StreamRoutes",
-    "envoy.api.v2.RateLimitDiscoveryService.ShouldRateLimit",
-  };
-
-  for (const auto& method : methods) {
-    if (google::protobuf::DescriptorPool::generated_pool()->FindMethodByName(method) == nullptr) {
-      std::cout << "Unable to find method descriptor for " << method << std::endl;
-      exit(EXIT_FAILURE);
-    }
-  }
-
-  exit(EXIT_SUCCESS);
+  envoy::api::v2::ClusterDiscoveryService::descriptor();
+  envoy::api::v2::EndpointDiscoveryService::descriptor();
+  envoy::api::v2::HealthDiscoveryService::descriptor();
+  envoy::api::v2::ListenerDiscoveryService::descriptor();
+  envoy::api::v2::RateLimitDiscoveryService::descriptor();
+  envoy::api::v2::RouteDiscoveryService::descriptor();
 }


### PR DESCRIPTION
* Add metadata to endpoints in EDS.

* Allow routes to specify a metadata_match. WeightedClusters can further
  specify an additional metadata_match based on weighting.

* Log all metadata. It makes sense to have available to the logging
  pipeline all metadata used during request processing, not just some
  that is explicitly annotated. This then makes available the endpoint's
  metadata for log consumption. The tradeoff is that this will increase
  log sizes when metadata is plentiful. We may want to consider a way to
  filter this in logs in the future.

Fixes #81 and #91.