### PR TITLE
api: remove cc_generic_services dependency.

### DIFF
--- a/api/cds.proto
+++ b/api/cds.proto
@@ -11,8 +11,6 @@ import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
-option cc_generic_services = true;
-
 // Return list of all clusters this proxy will load balance to.
 service ClusterDiscoveryService {
   rpc StreamClusters(stream DiscoveryRequest)

--- a/api/eds.proto
+++ b/api/eds.proto
@@ -9,8 +9,6 @@ import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
-option cc_generic_services = true;
-
 service EndpointDiscoveryService {
   // The resource_names field in DiscoveryRequest specifies a list of clusters
   // to subscribe to updates for.

--- a/api/hds.proto
+++ b/api/hds.proto
@@ -8,8 +8,6 @@ import "api/health_check.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 
-option cc_generic_services = true;
-
 // HDS is Health Discovery Service. It compliments Envoy’s health checking
 // service by designating this Envoy to be a healthchecker for a subset of hosts
 // in the cluster. The status of these health checks will be reported to the

--- a/api/lds.proto
+++ b/api/lds.proto
@@ -14,8 +14,6 @@ import "google/api/annotations.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
-option cc_generic_services = true;
-
 // The Envoy instance initiates an RPC at startup to discover a list of
 // listeners. Updates are delivered via streaming from the LDS server and
 // consist of a complete update of all listeners. Existing connections will be

--- a/api/rds.proto
+++ b/api/rds.proto
@@ -12,8 +12,6 @@ import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
-option cc_generic_services = true;
-
 // The resource_names field in DiscoveryRequest specifies a route configuration.
 // This allows an Envoy configuration with multiple HTTP listeners (and
 // associated HTTP connection manager filters) to use different route

--- a/api/rlds.proto
+++ b/api/rlds.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 option go_package = "ratelimit";
 
-option cc_generic_services = true;
-
 package envoy.api.v2;
 
 service RateLimitDiscoveryService {

--- a/test/build/build_test.cc
+++ b/test/build/build_test.cc
@@ -1,3 +1,6 @@
+#include <iostream>
+#include <cstdlib>
+
 #include "api/cds.pb.h"
 #include "api/eds.pb.h"
 #include "api/hds.pb.h"
@@ -7,10 +10,26 @@
 
 // Basic C++ build/link validation for the v2 xDS APIs.
 int main(int argc, char *argv[]) {
-  envoy::api::v2::ClusterDiscoveryService::descriptor();
-  envoy::api::v2::EndpointDiscoveryService::descriptor();
-  envoy::api::v2::HealthDiscoveryService::descriptor();
-  envoy::api::v2::ListenerDiscoveryService::descriptor();
-  envoy::api::v2::RateLimitDiscoveryService::descriptor();
-  envoy::api::v2::RouteDiscoveryService::descriptor();
+  const auto methods = {
+    "envoy.api.v2.ClusterDiscoveryService.FetchClusters",
+    "envoy.api.v2.ClusterDiscoveryService.StreamClusters",
+    "envoy.api.v2.EndpointDiscoveryService.FetchEndpoints",
+    "envoy.api.v2.EndpointDiscoveryService.StreamEndpoints",
+    "envoy.api.v2.HealthDiscoveryService.FetchHealthCheck",
+    "envoy.api.v2.HealthDiscoveryService.StreamHealthCheck",
+    "envoy.api.v2.ListenerDiscoveryService.FetchListeners",
+    "envoy.api.v2.ListenerDiscoveryService.StreamListeners",
+    "envoy.api.v2.RouteDiscoveryService.FetchRoutes",
+    "envoy.api.v2.RouteDiscoveryService.StreamRoutes",
+    "envoy.api.v2.RateLimitDiscoveryService.ShouldRateLimit",
+  };
+
+  for (const auto& method : methods) {
+    if (google::protobuf::DescriptorPool::generated_pool()->FindMethodByName(method) == nullptr) {
+      std::cout << "Unable to find method descriptor for " << method << std::endl;
+      exit(EXIT_FAILURE);
+    }
+  }
+
+  exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
We can dynamically discover service/method descriptors in Envoy, so we
don't need to generate any C++ stubs for this. This simplifies the
Google import and removes an unnecessary build output.