### PR TITLE
api: static bootstrap proto definition.

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -18,6 +18,15 @@ api_proto_library(
 )
 
 api_proto_library(
+    name = "bootstrap",
+    srcs = ["bootstrap.proto"],
+    deps = [
+        ":base",
+        ":cds",
+    ],
+)
+
+api_proto_library(
     name = "health_check",
     srcs = ["health_check.proto"],
     deps = [":base"],

--- a/api/base.proto
+++ b/api/base.proto
@@ -5,6 +5,7 @@ package envoy.api.v2;
 import "api/address.proto";
 
 import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -115,13 +116,17 @@ message DiscoveryResponse {
 message ApiConfigSource {
   // APIs may be fetched via either REST or gRPC.
   enum ApiType {
-    REST = 0;
-    GRPC = 1;
+    // REST legacy corresponds to the v1 API.
+    REST_LEGACY = 0;
+    REST = 1;
+    GRPC = 2;
   }
   ApiType api_type = 1;
   // Multiple cluster names may be provided. If > 1 cluster is defined, clusters
   // will be cycled through if any kind of failure occurs.
   repeated string cluster_name = 2;
+  // For REST APIs, the delay between successive polls.
+  google.protobuf.Duration refresh_delay = 3;
 }
 
 // Configuration for listeners, clusters, routes, endpoints etc. may either be

--- a/api/base.proto
+++ b/api/base.proto
@@ -111,3 +111,25 @@ message DiscoveryResponse {
   string version_info = 1;
   repeated google.protobuf.Any resources = 2;
 }
+
+message ApiConfigSource {
+  // APIs may be fetched via either REST or gRPC.
+  enum ApiType {
+    REST = 0;
+    GRPC = 1;
+  }
+  ApiType api_type = 1;
+  // Multiple cluster names may be provided. If > 1 cluster is defined, clusters
+  // will be cycled through if any kind of failure occurs.
+  repeated string cluster_name = 2;
+}
+
+// Configuration for listeners, clusters, routes, endpoints etc. may either be
+// sourced from the filesystem or from an API source. Filesystem configs are
+// watched with inotify for updates.
+message ConfigSource {
+  oneof config_source_specifier {
+    string path = 1;
+    ApiConfigSource api_config_source = 2;
+  }
+}

--- a/api/bootstrap.proto
+++ b/api/bootstrap.proto
@@ -1,0 +1,26 @@
+// This proto is expected to be provided on disk or via the command-line to
+// Envoy. It provides sufficient information for Envoy to fetch the rest of
+// its configuration from either disk or management server(s).
+
+syntax = "proto3";
+
+package envoy.api.v2;
+
+import "api/base.proto";
+import "api/cds.proto";
+
+message Bootstrap {
+  // Node identity to present to the management server and for instance
+  // identification purposes (e.g. in generated headers).
+  Node node = 1;
+  // All Listeners are provided by a single LDS configuration source.
+  ConfigSource lds_config = 2;
+  // All post-bootstrap Cluster definitions are provided by a single CDS
+  // configuration source.
+  ConfigSource cds_config = 3;
+  // If a network based configuration source is specified for cds_config, it's
+  // necessary to have some initial cluster definitions available to allow Envoy
+  // to know how to speak to the management server. These cluster definitions
+  // may not use EDS (i.e. they should be static IP or DNS-based).
+  repeated Cluster bootstrap_clusters = 4;
+}

--- a/api/bootstrap.proto
+++ b/api/bootstrap.proto
@@ -23,4 +23,5 @@ message Bootstrap {
   // to know how to speak to the management server. These cluster definitions
   // may not use EDS (i.e. they should be static IP or DNS-based).
   repeated Cluster bootstrap_clusters = 4;
+  // TODO(htuch): Add support for HDS.
 }

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -85,11 +85,14 @@ message Cluster {
   }
   DiscoveryType type = 2;
 
+  // Only valid when discovery type is EDS.
+  ConfigSource eds_config = 3;
+
   // The timeout for new network connections to hosts in the cluster.
-  google.protobuf.Duration connect_timeout = 3;
+  google.protobuf.Duration connect_timeout = 4;
   // Soft limit on size of the cluster’s connections read and write buffers. If
   // unspecified, an implementation defined default is applied (1MiB).
-  google.protobuf.UInt32Value per_connection_buffer_limit_bytes = 4;
+  google.protobuf.UInt32Value per_connection_buffer_limit_bytes = 5;
 
   // The load balancer type to use when picking a host in the cluster.
   enum LbPolicy {
@@ -98,38 +101,38 @@ message Cluster {
     RING_HASH = 2;
     RANDOM = 3;
   }
-  LbPolicy lb_policy = 5;
+  LbPolicy lb_policy = 6;
 
   // If the service discovery type is static, static_hosts is required. If the
   // service discovery type is strict_dns or logical_dns, dns_hosts is required.
   oneof hosts_specifier {
-    ResolvedAddresses static_hosts = 6;
-    UnresolvedAddress dns_hosts = 7;
+    ResolvedAddresses static_hosts = 7;
+    UnresolvedAddress dns_hosts = 8;
   }
 
   // Optional active health checking configuration for the cluster. If no
   // configuration is specified no health checking will be done and all cluster
   // members will be considered healthy at all times.
-  repeated HealthCheck health_checks = 8;
+  repeated HealthCheck health_checks = 9;
 
   // Optional maximum requests for a single upstream connection. This parameter
   // is respected by both the HTTP/1.1 and HTTP/2 connection pool
   // implementations. If not specified, there is no limit. Setting this
   // parameter to 1 will effectively disable keep alive.
-  google.protobuf.UInt32Value max_requests_per_connection = 9;
+  google.protobuf.UInt32Value max_requests_per_connection = 10;
 
   // Optional circuit breaking settings for the cluster.
-  CircuitBreakers circuit_breakers = 10;
+  CircuitBreakers circuit_breakers = 11;
 
   // The TLS configuration for connections to the upstream cluster. If no TLS
   // configuration is specified, TLS will not be used for new connections.
-  UpstreamTlsContext tls_context = 11;
+  UpstreamTlsContext tls_context = 12;
 
   oneof protocol_options {
-    TcpProtocolOptions tcp_protocol_options = 12;
-    Http1ProtocolOptions http_protocol_options  = 13;
-    Http2ProtocolOptions http2_protocol_options  = 14;
-    GrpcProtocolOptions grpc_protocol_options  = 15;
+    TcpProtocolOptions tcp_protocol_options = 13;
+    Http1ProtocolOptions http_protocol_options  = 14;
+    Http2ProtocolOptions http2_protocol_options  = 15;
+    GrpcProtocolOptions grpc_protocol_options  = 16;
   }
 
   // If the dns refresh rate is specified and the cluster type is either
@@ -137,7 +140,7 @@ message Cluster {
   // rate. If this setting is not specified, the value defaults to 5000. For
   // cluster types other than strict_dns and logical_dns this setting is
   // ignored.
-  google.protobuf.Duration dns_refresh_rate = 16;
+  google.protobuf.Duration dns_refresh_rate = 17;
 
   // If specified, outlier detection will be enabled for this upstream cluster.
   message OutlierDetection {
@@ -183,5 +186,5 @@ message Cluster {
     // be 1900. Defaults to 1900.
     google.protobuf.UInt32Value success_rate_stdev_factor = 9;
   }
-  OutlierDetection outlier_detection = 17;
+  OutlierDetection outlier_detection = 18;
 }

--- a/api/filter/http_connection_manager.proto
+++ b/api/filter/http_connection_manager.proto
@@ -11,11 +11,8 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 message Rds {
-  // The name of an upstream cluster that hosts the route discovery service. The
-  // cluster must run a service that implements the RDS API. NOTE: This is the
-  // name of a cluster defined in the cluster manager configuration, not the
-  // full definition of a cluster as in the case of SDS and CDS.
-  string cluster = 1;
+  // Configuration source specifier for RDS.
+  ConfigSource rds_config = 1;
 
   // The name of the route configuration. This name will be passed to the RDS
   // API. This allows an Envoy configuration with multiple HTTP listeners (and


### PR DESCRIPTION
This patch adds a static bootstrap proto that is expected to be provided
on the filesystem or command-line. This should enable Envoy to then
either fetch the rest of config from disk or reach out to the various
management servers for the rest of the APIs.

Fixes #93.