### PR TITLE
lds: eliminate direction from filter config.

### DIFF
--- a/api/filter/http_connection_manager.proto
+++ b/api/filter/http_connection_manager.proto
@@ -160,24 +160,13 @@ message AccessLog {
 }
 
 message HttpFilter {
-  // The type of filter to instantiate. Most filters implement a specific type,
-  // though it is theoretically possible for a filter to be written such that it
-  // can operate in multiple modes. Supported types are decoder, encoder, and
-  // both.
-  enum Type {
-    BOTH = 0;
-    DECODER = 1;
-    ENCODER = 2;
-  }
-  Type type = 1;
-
   // The name of the filter to instantiate. The name must match a supported
   // filter.
-  string name = 2;
+  string name = 1;
 
   // Filter specific configuration which depends on the filter being
   // instantiated. See the supported filters for further documentation.
-  google.protobuf.Struct config = 3;
+  google.protobuf.Struct config = 2;
 }
 
 message HttpConnectionManager {

--- a/api/lds.proto
+++ b/api/lds.proto
@@ -33,21 +33,12 @@ service ListenerDiscoveryService {
 }
 
 message Filter {
-  // The type of filter to instantiate. Most filters implement a specific type,
-  // though it is theoretically possible for a filter to be written such that it
-  // can operate in multiple modes. Supported types are read, write, and both.
-  enum Type {
-    BOTH = 0;
-    READ = 1;
-    WRITE = 2;
-  }
-  Type type = 1;
   // The name of the filter to instantiate. The name must match a supported
   // filter.
-  string name = 2;
+  string name = 1;
   // Filter specific configuration which depends on the filter being
   // instantiated. See the supported filters for further documentation.
-  google.protobuf.Struct config = 3;
+  google.protobuf.Struct config = 2;
 }
 
 // Specifies the match criteria for selecting a specific filter chain for a


### PR DESCRIPTION
Direction is implied at the C++ type level, putting this in the config
is redundant and can making changes to the C++ implementations difficult
to synchronize between binary and config.

Fixes #63.