### PR TITLE
cds: clarify the role of set vs. unset http2_protocol_options.

### DIFF
--- a/api/cds.proto
+++ b/api/cds.proto
@@ -131,6 +131,12 @@ message Cluster {
   oneof protocol_options {
     TcpProtocolOptions tcp_protocol_options = 13;
     Http1ProtocolOptions http_protocol_options  = 14;
+    // Even if default HTTP2 protocol options are desired, this field must be
+    // set so that Envoy will assume that the upstream supports HTTP/2 when
+    // making new HTTP connection pool connections. Currently, Envoy only
+    // supports prior knowledge for upstream connections. Even if TLS is used
+    // with ALPN, http2 must be specified. As an aside this allows HTTP/2
+    // connections to happen over plain text.
     Http2ProtocolOptions http2_protocol_options  = 15;
     GrpcProtocolOptions grpc_protocol_options  = 16;
   }


### PR DESCRIPTION
This effectively replaces the "features" field in the v1 JSON.