### PR TITLE
cds/protocol: split out shared frontend/backend protocol options.

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -48,6 +48,7 @@ api_proto_library(
         ":base",
         ":health_check",
         ":tls_context",
+        ":protocol",
     ],
 )
 
@@ -81,6 +82,11 @@ api_proto_library(
         ":base",
         ":tls_context",
     ],
+)
+
+api_proto_library(
+    name = "protocol",
+    srcs = ["protocol.proto"],
 )
 
 api_proto_library(

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -5,6 +5,7 @@ package envoy.api.v2;
 import "api/address.proto";
 import "api/base.proto";
 import "api/health_check.proto";
+import "api/protocol.proto";
 import "api/tls_context.proto";
 
 import "google/api/annotations.proto";
@@ -49,25 +50,6 @@ message CircuitBreakers {
     google.protobuf.UInt32Value max_retries = 5;
   }
   repeated Thresholds thresholds = 1;
-}
-
-
-message TcpProtocolOptions {
-}
-
-message Http1ProtocolOptions {
-}
-
-message Http2ProtocolOptions {
-  google.protobuf.UInt32Value per_stream_buffer_limit_bytes = 1;
-  google.protobuf.UInt32Value hpack_table_size = 2;
-  google.protobuf.UInt32Value max_concurrent_streams = 3;
-  google.protobuf.UInt32Value initial_stream_window_size = 4;
-  google.protobuf.UInt32Value initial_connection_window_size = 5;
-}
-
-message GrpcProtocolOptions {
-  Http2ProtocolOptions http2_protocol_options = 1;
 }
 
 message Cluster {

--- a/api/filter/http_connection_manager.proto
+++ b/api/filter/http_connection_manager.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package envoy.api.v2.filter;
 
 import "api/base.proto";
-import "api/cds.proto";
+import "api/protocol.proto";
 import "api/rds.proto";
 
 import "google/protobuf/duration.proto";

--- a/api/protocol.proto
+++ b/api/protocol.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package envoy.api.v2;
+
+import "google/protobuf/wrappers.proto";
+
+message TcpProtocolOptions {
+}
+
+message Http1ProtocolOptions {
+}
+
+message Http2ProtocolOptions {
+  google.protobuf.UInt32Value per_stream_buffer_limit_bytes = 1;
+  google.protobuf.UInt32Value hpack_table_size = 2;
+  google.protobuf.UInt32Value max_concurrent_streams = 3;
+  google.protobuf.UInt32Value initial_stream_window_size = 4;
+  google.protobuf.UInt32Value initial_connection_window_size = 5;
+}
+
+message GrpcProtocolOptions {
+  Http2ProtocolOptions http2_protocol_options = 1;
+}


### PR DESCRIPTION
Avoid false dependency on CDS by HTTP connection manager. This also
manifests at the code level when implementing v1 -> v2 translation.