### PR TITLE
Removing unused per_stream_buffer_limit_bytes

### DIFF
--- a/api/protocol.proto
+++ b/api/protocol.proto
@@ -11,11 +11,10 @@ message Http1ProtocolOptions {
 }
 
 message Http2ProtocolOptions {
-  google.protobuf.UInt32Value per_stream_buffer_limit_bytes = 1;
-  google.protobuf.UInt32Value hpack_table_size = 2;
-  google.protobuf.UInt32Value max_concurrent_streams = 3;
-  google.protobuf.UInt32Value initial_stream_window_size = 4;
-  google.protobuf.UInt32Value initial_connection_window_size = 5;
+  google.protobuf.UInt32Value hpack_table_size = 1;
+  google.protobuf.UInt32Value max_concurrent_streams = 2;
+  google.protobuf.UInt32Value initial_stream_window_size = 3;
+  google.protobuf.UInt32Value initial_connection_window_size = 4;
 }
 
 message GrpcProtocolOptions {


### PR DESCRIPTION
I also renumbered existing variables.  I know this isn't something which should normally be done but as we're not using v2 yet I assume we don't need to be backwards compatible so I figured I'd keep it clean.  