### PR TITLE
base: add cluster to Node and clarify what is required.

### DIFF
--- a/api/base.proto
+++ b/api/base.proto
@@ -25,12 +25,15 @@ message Locality {
 
 // Identifies a specific Envoy instance. Remote server may have per Envoy configuration.
 message Node {
+  // An opaque node identifier for the Envoy node. This must be set.
   string id = 1;
-  google.protobuf.Struct metadata = 2;
-  Locality locality = 3;
+  // The cluster that the Envoy node belongs to. This must be set.
+  string cluster = 2;
+  google.protobuf.Struct metadata = 3;
+  Locality locality = 4;
   // This is motivated by informing a management server during canary which
   // version of Envoy is being tested in a heterogeneous fleet.
-  string build_version = 4;
+  string build_version = 5;
 }
 
 message Endpoint {


### PR DESCRIPTION
Since we expected both node name and cluster in v1, it makes sense to
continue providing this to management servers. We don't need to use
metadata for cluster if it is required.