### PR TITLE
Adding a "bind to address" to the bootstrap proto

### DIFF
--- a/api/bootstrap.proto
+++ b/api/bootstrap.proto
@@ -6,8 +6,16 @@ syntax = "proto3";
 
 package envoy.api.v2;
 
+import "api/address.proto";
 import "api/base.proto";
 import "api/cds.proto";
+
+// An extensible structure containing the address Envoy should bind to when establishing upstream
+// connections.
+message BindTo {
+  // The address Envoy should bind to when establishing upstream connections.
+  ResolvedAddress bind_to_address = 1;
+}
 
 message Bootstrap {
   // Node identity to present to the management server and for instance
@@ -25,5 +33,7 @@ message Bootstrap {
   // to know how to speak to the management server. These cluster definitions
   // may not use EDS (i.e. they should be static IP or DNS-based).
   repeated Cluster bootstrap_clusters = 5;
+  // Optional configuration used to bind newly established upstream connections.
+  BindTo bind_to_config = 6;
   // TODO(htuch): Add support for HDS.
 }

--- a/api/bootstrap.proto
+++ b/api/bootstrap.proto
@@ -12,9 +12,9 @@ import "api/cds.proto";
 
 // An extensible structure containing the address Envoy should bind to when establishing upstream
 // connections.
-message BindTo {
+message UpstreamBindConfig {
   // The address Envoy should bind to when establishing upstream connections.
-  ResolvedAddress bind_to_address = 1;
+  ResolvedAddress source_address = 1;
 }
 
 message Bootstrap {
@@ -34,6 +34,6 @@ message Bootstrap {
   // may not use EDS (i.e. they should be static IP or DNS-based).
   repeated Cluster bootstrap_clusters = 5;
   // Optional configuration used to bind newly established upstream connections.
-  BindTo bind_to_config = 6;
+  UpstreamBindConfig upstream_bind_config = 6;
   // TODO(htuch): Add support for HDS.
 }


### PR DESCRIPTION
For envoy/#1411

Adding it in a structured proto because in the long run I anticipate us wanting to have per-cluster port ranges we bind to and it makes sense to me if we're going to eventually allow the bootstrap and cluster config to interact that we stick all the interacting bits in another message.

If this is over-designing I can make it a straight up address and we can link with documentation in future :-)