### PR TITLE
rds: add missing validate_clusters/use_websockets.

### DIFF
--- a/api/rds.proto
+++ b/api/rds.proto
@@ -233,6 +233,24 @@ message RouteAction {
     }
   }
   repeated HashPolicy hash_policy = 15;
+
+  // Indicates that a HTTP/1.1 client connection to this particular route
+  // should be allowed (and expected) to upgrade to a WebSocket connection. The
+  // default is false.
+  //
+  // Attention
+  //
+  // If set to true, Envoy will expect the first request matching this route to
+  // contain WebSocket upgrade headers. If the headers are not present, the
+  // connection will be rejected. If set to true, Envoy will setup plain TCP
+  // proxying between the client and the upstream server. Hence, an upstream
+  // server that rejects the WebSocket upgrade request is also responsible for
+  // closing the associated connection. Until then, Envoy will continue to
+  // proxy data from the client to the upstream server.
+  //
+  // Redirects, timeouts and retries are not supported on routes where
+  // websocket upgrades are allowed.
+  google.protobuf.BoolValue use_websocket = 16;
 }
 
 message RedirectAction {
@@ -449,4 +467,16 @@ message RouteConfiguration {
   // routed by the HTTP connection manager. In the presence of duplicate
   // header keys, precendence rules apply.
   repeated HeaderValueOption request_headers_to_add = 6;
+
+  // An optional boolean that specifies whether the clusters that the route
+  // table refers to will be validated by the cluster manager. If set to true
+  // and a route refers to a non-existent cluster, the route table will not
+  // load. If set to false and a route refers to a non-existent cluster, the
+  // route table will load and the router filter will return a 404 if the route
+  // is selected at runtime. This setting defaults to true if the route table
+  // is statically defined via the route_config option. This setting default to
+  // false if the route table is loaded dynamically via the rds option. Users
+  // may which to override the default behavior in certain cases (for example
+  // when using CDS with a static route table).
+  google.protobuf.BoolValue validate_clusters = 7;
 }


### PR DESCRIPTION
This completes the RDS API changes needed for the v1 JSON translation.