### PR TITLE
eds: make UpstreamLocalityStats work with scalar totals.

### DIFF
--- a/api/eds.proto
+++ b/api/eds.proto
@@ -130,34 +130,24 @@ message UpstreamLocalityStats {
 
   // The total number of requests sent by this Envoy since the last report. A
   // single HTTP or gRPC request or stream is counted as one request. A TCP
-  // connection is also treated as one request. The following property should
-  // hold:
+  // connection is also treated as one request. There is no explicit
+  // total_requests field below, but it may be inferred from:
   //   total_requests = total_successful_requests + total_requests_in_progress +
-  //       sum(tcp_errors) + sum(http_errors) + sum(grpc_errors) +
-  //       total_dropped_requests
-  uint64 total_requests = 2;
+  //       total_error_requests + total_dropped_requests
+  // The total number of successfully completed requests.
+  uint64 total_successful_requests = 2;
   // The total number of unfinished requests
   uint64 total_requests_in_progress = 3;
-  // The number of errors since the last report.
-  enum TcpErrorType {
-    TIMEOUT = 0;
-    // TODO(htuch): Fill in additional TcpErrorType values.
-  }
-  // TODO(htuch): Ideally we would have the tcp_errors key be TcpErrorType, but
-  // enums are not supported as map key types. Maybe make this a repeated
-  // message with TcpErrorType x uint64 pairs.
-  map<uint32, uint64> tcp_errors = 4;
-  // HTTP status code, count
-  map<uint32, uint64> http_errors = 5;
-  // GRCP status code, count
-  map<uint32, uint64> grpc_errors = 6;
-
-  // The number of dropped requests since the last report. This covers requests
+  // The total number of requests that failed due to a network or protocol
+  // error. This  includes for HTTP all non-200 error codes (and for gRPC, all
+  // non-OK failures).
+  uint64 total_error_requests = 4;
+  // The total number of dropped requests. This covers requests
   // deliberately dropped by the drop_overload policy and circuit breaking.
-  uint64 total_dropped_requests = 7;
+  uint64 total_dropped_requests = 5;
 
   // Stats for multi-dimensional load balancing.
-  repeated EndpointLoadMetricStats load_metric_stats = 8;
+  repeated EndpointLoadMetricStats load_metric_stats = 6;
 }
 
 // Per cluster stats


### PR DESCRIPTION
Previously, we had a complex way of inferring total error requests from
map value aggregation. This PR removes the error maps for now, providing
simple scalar totals instead. This will simplify
https://github.com/lyft/envoy/issues/1286.

We expect to add the error maps as an additional mechanism, orthogonal to
the scalar totals, later on, as standard proto extension.