### PR TITLE
address: remove square brack requirements for IPv6.

### DIFF
--- a/api/address.proto
+++ b/api/address.proto
@@ -56,8 +56,7 @@ message ResolvedAddress {
       TCP = 0;
     }
     Protocol protocol = 1;
-    // IP address as returned by inet_ntop(), with IPv6 addresses additionally
-    // enclosed in brackets, e.g. [2001:700:300:1800::f].
+    // IP address as returned by inet_ntop().
     string ip_address = 2;
     google.protobuf.UInt32Value port = 3;
   }


### PR DESCRIPTION
We can just try parse IPv6, and failing that do IPv4.