### PR TITLE
bootstrap: add dependency on ":address".

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -23,6 +23,7 @@ api_proto_library(
     name = "bootstrap",
     srcs = ["bootstrap.proto"],
     deps = [
+        ":address",
         ":base",
         ":cds",
     ],


### PR DESCRIPTION
Missed in commit aab56bd6.