### PR TITLE
address: merge Resolved/Unresolved address types.

### DIFF
--- a/api/address.proto
+++ b/api/address.proto
@@ -10,10 +10,14 @@ message Pipe {
   string path = 1;
 }
 
-// Unresolved addresses contain either named hosts or ports that require
-// resolution via DNS or an optional custom Resolver.
-message UnresolvedAddress {
-  message NamedAddress {
+// Addresses specify either a logical or physical address and port, which are
+// used to tell Envoy where to bind/listen, connect to upstream and find
+// management servers. They may optionally name a resolver that will be used at
+// runtime for further transformation. Resolution may also be performed in a
+// context dependent manner, e.g. when an Address is used for an upstream
+// logical DNS host.
+message Address {
+  message SocketAddress {
     enum Protocol {
       TCP = 0;
     }
@@ -25,47 +29,19 @@ message UnresolvedAddress {
     // DNS.
     string address = 2;
     oneof port_specifier {
-      google.protobuf.UInt32Value port = 3;
-      string service_name = 4;
+      uint32 port_value = 3;
+      // This is only valid if DNS SRV or if resolver_name is specified below
+      // and the named resolver is capable of named port resolution.
+      string named_port = 4;
     }
   }
-  // Support pluggable resolvers.
-  message Resolver {
-    // Name of the resolver. This must have been registered with Envoy.
-    string name = 1;
-    // TODO(htuch): Do we need further extensibility or should we collapse
-    // Resolver to a string?
-  }
-  // If not specified, the default DNS resolver is used.
-  Resolver resolver = 1;
+  // Name of the resolver. This must have been registered with Envoy. If this is
+  // empty, a context dependent default applies. If the address is expected to
+  // be a hostname, it will be DNS resolution. If the address is expected to be
+  // a concrete IP address, no resolution will occur.
+  string resolver_name = 1;
   oneof address {
-    NamedAddress named_address = 2;
+    SocketAddress named_address = 2;
     Pipe pipe = 3;
   }
-}
-
-message UnresolvedAddresses {
-  repeated UnresolvedAddress addresses = 1;
-}
-
-// A ResolvedAddress identifies a concrete socket or UDS path and is not subject
-// to further resolution via DNS or custom resolvers.
-message ResolvedAddress {
-  message SocketAddress {
-    enum Protocol {
-      TCP = 0;
-    }
-    Protocol protocol = 1;
-    // IP address as returned by inet_ntop().
-    string ip_address = 2;
-    google.protobuf.UInt32Value port = 3;
-  }
-  oneof address {
-    SocketAddress socket_address = 2;
-    Pipe pipe = 3;
-  }
-}
-
-message ResolvedAddresses {
-  repeated ResolvedAddress addresses = 1;
 }

--- a/api/base.proto
+++ b/api/base.proto
@@ -37,7 +37,7 @@ message Node {
 }
 
 message Endpoint {
-  ResolvedAddress address = 1;
+  Address address = 1;
 }
 
 // Metadata provides additional inputs to filters based on matched listeners,

--- a/api/bootstrap.proto
+++ b/api/bootstrap.proto
@@ -14,7 +14,7 @@ import "api/cds.proto";
 // connections.
 message UpstreamBindConfig {
   // The address Envoy should bind to when establishing upstream connections.
-  ResolvedAddress source_address = 1;
+  Address source_address = 1;
 }
 
 message Bootstrap {

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -94,42 +94,39 @@ message Cluster {
   }
   LbPolicy lb_policy = 6;
 
-  // If the service discovery type is static, static_hosts is required. If the
-  // service discovery type is strict_dns or logical_dns, dns_hosts is required.
-  oneof hosts_specifier {
-    ResolvedAddresses static_hosts = 7;
-    UnresolvedAddresses dns_hosts = 8;
-  }
+  // If the service discovery type is static, strict_dns or logical_dns, then
+  // hosts is required.
+  repeated Address hosts = 7;
 
   // Optional active health checking configuration for the cluster. If no
   // configuration is specified no health checking will be done and all cluster
   // members will be considered healthy at all times.
-  repeated HealthCheck health_checks = 9;
+  repeated HealthCheck health_checks = 8;
 
   // Optional maximum requests for a single upstream connection. This parameter
   // is respected by both the HTTP/1.1 and HTTP/2 connection pool
   // implementations. If not specified, there is no limit. Setting this
   // parameter to 1 will effectively disable keep alive.
-  google.protobuf.UInt32Value max_requests_per_connection = 10;
+  google.protobuf.UInt32Value max_requests_per_connection = 9;
 
   // Optional circuit breaking settings for the cluster.
-  CircuitBreakers circuit_breakers = 11;
+  CircuitBreakers circuit_breakers = 10;
 
   // The TLS configuration for connections to the upstream cluster. If no TLS
   // configuration is specified, TLS will not be used for new connections.
-  UpstreamTlsContext tls_context = 12;
+  UpstreamTlsContext tls_context = 11;
 
   oneof protocol_options {
-    TcpProtocolOptions tcp_protocol_options = 13;
-    Http1ProtocolOptions http_protocol_options  = 14;
+    TcpProtocolOptions tcp_protocol_options = 12;
+    Http1ProtocolOptions http_protocol_options  = 13;
     // Even if default HTTP2 protocol options are desired, this field must be
     // set so that Envoy will assume that the upstream supports HTTP/2 when
     // making new HTTP connection pool connections. Currently, Envoy only
     // supports prior knowledge for upstream connections. Even if TLS is used
     // with ALPN, http2 must be specified. As an aside this allows HTTP/2
     // connections to happen over plain text.
-    Http2ProtocolOptions http2_protocol_options  = 15;
-    GrpcProtocolOptions grpc_protocol_options  = 16;
+    Http2ProtocolOptions http2_protocol_options  = 14;
+    GrpcProtocolOptions grpc_protocol_options  = 15;
   }
 
   // If the dns refresh rate is specified and the cluster type is either
@@ -137,7 +134,7 @@ message Cluster {
   // rate. If this setting is not specified, the value defaults to 5000. For
   // cluster types other than strict_dns and logical_dns this setting is
   // ignored.
-  google.protobuf.Duration dns_refresh_rate = 17;
+  google.protobuf.Duration dns_refresh_rate = 16;
 
   // The DNS IP address resolution policy. The options are v4_only, v6_only, and
   // auto. If this setting is not specified, the value defaults to v4_only. When
@@ -153,14 +150,14 @@ message Cluster {
     V4_ONLY = 1;
     V6_ONLY = 2;
   }
-  DnsLookupFamily dns_lookup_family = 18;
+  DnsLookupFamily dns_lookup_family = 17;
 
   // If DNS resolvers are specified and the cluster type is either strict_dns,
   // or logical_dns, this value is used to specify the cluster’s dns resolvers.
   // If this setting is not specified, the value defaults to the default
   // resolver, which uses /etc/resolv.conf for configuration. For cluster types
   // other than strict_dns and logical_dns this setting is ignored.
-  ResolvedAddresses dns_resolvers = 19;
+  repeated Address dns_resolvers = 18;
 
   // If specified, outlier detection will be enabled for this upstream cluster.
   message OutlierDetection {
@@ -206,7 +203,7 @@ message Cluster {
     // be 1900. Defaults to 1900.
     google.protobuf.UInt32Value success_rate_stdev_factor = 9;
   }
-  OutlierDetection outlier_detection = 20;
+  OutlierDetection outlier_detection = 19;
 
   // The interval for removing stale hosts from a cluster type
   // original_dst.  Hosts are considered stale if they have not been used
@@ -219,5 +216,5 @@ message Cluster {
   // on opening new connections.  If this setting is not specified, the
   // value defaults to 5000ms. For cluster types other than original_dst
   // this setting is ignored.
-  google.protobuf.Duration cleanup_interval = 21;
+  google.protobuf.Duration cleanup_interval = 20;
 }

--- a/api/lds.proto
+++ b/api/lds.proto
@@ -106,8 +106,13 @@ message FilterChain {
 }
 
 message Listener {
+  // The unique name of the listener. If no name is provided, Envoy will generate a
+  // UUID for internal use. The name is used for dynamic listener update and removal
+  // via the LDS APIs.
+  string name = 1;
+
   // The address that the listener should listen on.
-  UnresolvedAddress address = 1;
+  Address address = 2;
 
   // A list of filter chains to consider for this listener. The FilterChain with
   // the most specific FilterChainMatch criteria is used on a connection. The
@@ -121,25 +126,20 @@ message Listener {
   //    a tie.
   // 3. The longest suffix match on the bound destination address is used to
   //    select the FilterChain from step 2 that is used.
-  repeated FilterChain filter_chains = 2;
+  repeated FilterChain filter_chains = 3;
 
   // If a connection is redirected using iptables, the port on which the proxy
   // receives it might be different from the original destination port. When
   // this flag is set to true, the listener uses the original destination
   // address and port during FilterChain matching. Default is false.
-  google.protobuf.BoolValue use_original_dst = 3;
+  google.protobuf.BoolValue use_original_dst = 4;
 
   // Soft limit on size of the listener’s new connection read and write buffers.
   // If unspecified, an implementation defined default is applied (1MiB).
-  google.protobuf.UInt32Value per_connection_buffer_limit_bytes = 4;
+  google.protobuf.UInt32Value per_connection_buffer_limit_bytes = 5;
 
   // See base.Metadata description.
-  Metadata metadata = 5;
-
-  // The unique name of the listener. If no name is provided, Envoy will generate a
-  // UUID for internal use. The name is used for dynamic listener update and removal
-  // via the LDS APIs.
-  string name = 6;
+  Metadata metadata = 6;
 
   message DeprecatedV1 {
     // Whether the listener should bind to the port. A listener that doesn’t


### PR DESCRIPTION
Since we may want to use a resolver plugin in most places, it doesn't
make sense to have this strong separation between the two in the API.

Also bonus renumbering cleanup in LDS.