### PR TITLE
global and cluster-local bind config

### DIFF
--- a/api/address.proto
+++ b/api/address.proto
@@ -15,11 +15,11 @@ message SocketAddress {
     TCP = 0;
   }
   Protocol protocol = 1;
-  // Listeners will bind to the address if no bind_config is specified, and an empty
+  // The address for this socket.  Listeners will bind to the address.  An empty
   // address implies a bind to 0.0.0.0 or ::. It's still possible to distinguish on
   // address via the prefix/suffix matching in FilterChainMatch after connection.
   // For clusters, an address may be either an IP or hostname to be resolved via
-  // DNS.
+  // DNS.  If it is a hostname, resolve_name should be set.
   string address = 2;
   oneof port_specifier {
     uint32 port_value = 3;
@@ -27,6 +27,10 @@ message SocketAddress {
     // and the named resolver is capable of named port resolution.
     string named_port = 4;
   }
+  // The name of the resolver. This must have been registered with Envoy. If this is
+  // empty, a context dependent default applies. If address is a hostname this
+  // should be set.  If the address is a concrete IP address, no resolution will occur.
+  string resolver_name = 5;
 }
 
 message BindConfig {
@@ -36,18 +40,10 @@ message BindConfig {
 
 // Addresses specify either a logical or physical address and port, which are
 // used to tell Envoy where to bind/listen, connect to upstream and find
-// management servers. They may optionally name a resolver that will be used at
-// runtime for further transformation. Resolution may also be performed in a
-// context dependent manner, e.g. when an Address is used for an upstream
-// logical DNS host.
+// management servers.
 message Address {
-  // Name of the resolver. This must have been registered with Envoy. If this is
-  // empty, a context dependent default applies. If the address is expected to
-  // be a hostname, it will be DNS resolution. If the address is expected to be
-  // a concrete IP address, no resolution will occur.
-  string resolver_name = 1;
   oneof address {
-    SocketAddress named_address = 2;
-    Pipe pipe = 3;
+    SocketAddress named_address = 1;
+    Pipe pipe = 2;
   }
 }

--- a/api/address.proto
+++ b/api/address.proto
@@ -10,6 +10,30 @@ message Pipe {
   string path = 1;
 }
 
+message SocketAddress {
+  enum Protocol {
+    TCP = 0;
+  }
+  Protocol protocol = 1;
+  // Listeners will bind to the address if no bind_config is specified, and an empty
+  // address implies a bind to 0.0.0.0 or ::. It's still possible to distinguish on
+  // address via the prefix/suffix matching in FilterChainMatch after connection.
+  // For clusters, an address may be either an IP or hostname to be resolved via
+  // DNS.
+  string address = 2;
+  oneof port_specifier {
+    uint32 port_value = 3;
+    // This is only valid if DNS SRV or if resolver_name is specified below
+    // and the named resolver is capable of named port resolution.
+    string named_port = 4;
+  }
+}
+
+message BindConfig {
+  // The address to bind to when creating a socket.
+  SocketAddress source_address = 1;
+}
+
 // Addresses specify either a logical or physical address and port, which are
 // used to tell Envoy where to bind/listen, connect to upstream and find
 // management servers. They may optionally name a resolver that will be used at
@@ -17,24 +41,6 @@ message Pipe {
 // context dependent manner, e.g. when an Address is used for an upstream
 // logical DNS host.
 message Address {
-  message SocketAddress {
-    enum Protocol {
-      TCP = 0;
-    }
-    Protocol protocol = 1;
-    // For listeners, an empty address implies a bind to 0.0.0.0 or ::. It's
-    // still possible to distinguish on address via the prefix/suffix matching
-    // in FilterChainMatch after connection.
-    // For clusters, an address may be either an IP or hostname to be resolved via
-    // DNS.
-    string address = 2;
-    oneof port_specifier {
-      uint32 port_value = 3;
-      // This is only valid if DNS SRV or if resolver_name is specified below
-      // and the named resolver is capable of named port resolution.
-      string named_port = 4;
-    }
-  }
   // Name of the resolver. This must have been registered with Envoy. If this is
   // empty, a context dependent default applies. If the address is expected to
   // be a hostname, it will be DNS resolution. If the address is expected to be

--- a/api/bootstrap.proto
+++ b/api/bootstrap.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 
 package envoy.api.v2;
 
+import "api/address.proto";
 import "api/base.proto";
 import "api/cds.proto";
 
@@ -25,5 +26,8 @@ message Bootstrap {
   // to know how to speak to the management server. These cluster definitions
   // may not use EDS (i.e. they should be static IP or DNS-based).
   repeated Cluster bootstrap_clusters = 5;
+  // Optional configuration used to bind newly established upstream connections.
+  // This may be overridden on a per-cluster basis by upstream_bind_config in the cds_config.
+  BindConfig upstream_bind_config = 6;
   // TODO(htuch): Add support for HDS.
 }

--- a/api/cds.proto
+++ b/api/cds.proto
@@ -226,5 +226,7 @@ message Cluster {
   google.protobuf.Duration cleanup_interval = 20;
 
   // Optional configuration used to bind newly established upstream connections.
-  UpstreamBindConfig upstream_bind_config = 21;
+  // This overrides any bind_config specified in the bootstrap proto.
+  // If the addres and port are empty, no bind will be performed.
+  BindConfig upstream_bind_config = 21;
 }


### PR DESCRIPTION
This doesn't include adding config config to the listener address.  

aside: do we allow resolving pipes or should we have a class wrapping the resolver and the socket address?