### PR TITLE
lds/http_connection_manager: switch opaque filter configs to Any.

### DIFF
--- a/api/filter/http_connection_manager.proto
+++ b/api/filter/http_connection_manager.proto
@@ -7,7 +7,7 @@ import "api/protocol.proto";
 import "api/rds.proto";
 
 import "google/protobuf/duration.proto";
-import "google/protobuf/struct.proto";
+import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
 
 message Rds {
@@ -157,7 +157,7 @@ message HttpFilter {
 
   // Filter specific configuration which depends on the filter being
   // instantiated. See the supported filters for further documentation.
-  google.protobuf.Struct config = 2;
+  google.protobuf.Any config = 2;
 
   message DeprecatedV1 {
     string type = 1;

--- a/api/lds.proto
+++ b/api/lds.proto
@@ -11,7 +11,7 @@ import "api/base.proto";
 import "api/tls_context.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/struct.proto";
+import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
 
 // The Envoy instance initiates an RPC at startup to discover a list of
@@ -38,7 +38,7 @@ message Filter {
   string name = 1;
   // Filter specific configuration which depends on the filter being
   // instantiated. See the supported filters for further documentation.
-  google.protobuf.Struct config = 2;
+  google.protobuf.Any config = 2;
 
   message DeprecatedV1 {
     string type = 1;


### PR DESCRIPTION
google.protobuf.Any has a saner ASCII protobuf representation, and the
inbuilt type_url when performing JSON transformation will allow us to
feed the JSON representation into filter config factories and have them
able to distinguish between v1/v2 in a systematic way.